### PR TITLE
Chore(qdog 93): create test navbar blank page

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1228,6 +1228,7 @@ packages:
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
     engines: {node: '>=18'}
+
   dayjs@1.11.18:
     resolution: {integrity: sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==}
 
@@ -3727,6 +3728,7 @@ snapshots:
     dependencies:
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
+
   dayjs@1.11.18: {}
 
   debug@4.4.3:

--- a/src/app/under-construction/layout.test.tsx
+++ b/src/app/under-construction/layout.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * Under Construction Layout Tests
+ *
+ * Developed with assistance from Claude AI and ChatGPT for:
+ * - Testing layout structure and component rendering
+ * - Verifying sidebar and main content placement
+ * - Ensuring font variables and HTML attributes are applied correctly
+ * - Mocking external dependencies (fonts and Sidebar)
+ */
+
+// app/under-construction/layout.test.tsx
+import "@testing-library/jest-dom";
+import { render, screen } from "~tests/utils/custom-testing-library";
+import type { ReactNode } from "react";
+
+// Mock fonts so the body className concatenation is predictable
+jest.mock("../../lib/fonts", () => ({
+    dmSans: { variable: "dmSansVar" },
+    tsukimiRounded: { variable: "tsukimiRoundedVar" },
+}));
+
+// Mock Sidebar to a simple test double
+jest.mock("../../components/sidebar", () => () => (
+    <aside data-testid='sidebar-mock' />
+));
+
+import UnderConstructionLayout from "./layout";
+
+const renderLayout = (children: ReactNode) =>
+    render(<UnderConstructionLayout>{children}</UnderConstructionLayout>);
+
+describe("UnderConstructionLayout", () => {
+    it("renders html/body with lang and font variables", () => {
+        renderLayout(<div>child</div>);
+        const html = document.querySelector("html");
+        const body = document.querySelector("body");
+
+        expect(html).toHaveAttribute("lang", "en");
+        expect(body?.className).toContain("dmSansVar");
+        expect(body?.className).toContain("tsukimiRoundedVar");
+    });
+
+    it("renders grid with Sidebar and puts children inside <main>", () => {
+        renderLayout(<div data-testid='child' />);
+
+        // CSS modules are identity-mapped in tests, so these class names exist
+        const grid = document.querySelector(".layoutGrid");
+        expect(grid).toBeInTheDocument();
+
+        expect(screen.getByTestId("sidebar-mock")).toBeInTheDocument();
+
+        const main = document.querySelector("main.main");
+        expect(main).toBeInTheDocument();
+        expect(main).toContainElement(screen.getByTestId("child"));
+    });
+});

--- a/src/app/under-construction/layout.test.tsx
+++ b/src/app/under-construction/layout.test.tsx
@@ -5,50 +5,53 @@
  * - Testing layout structure and component rendering
  * - Verifying sidebar and main content placement
  * - Ensuring font variables and HTML attributes are applied correctly
- * - Mocking external dependencies (fonts and Sidebar)
+ * - Mocking external dependencies (fonts and sidebar)
  */
 
-// app/under-construction/layout.test.tsx
 import "@testing-library/jest-dom";
 import { render, screen } from "~tests/utils/custom-testing-library";
 import type { ReactNode } from "react";
+import UnderConstructionLayout from "./layout";
 
-// Mock fonts so the body className concatenation is predictable
+// mock fonts so the body className concatenation is predictable
 jest.mock("../../lib/fonts", () => ({
     dmSans: { variable: "dmSansVar" },
     tsukimiRounded: { variable: "tsukimiRoundedVar" },
 }));
 
-// Mock Sidebar to a simple test double
+// mock Sidebar to a simple test double
 jest.mock("../../components/sidebar", () => () => (
     <aside data-testid='sidebar-mock' />
 ));
-
-import UnderConstructionLayout from "./layout";
 
 const renderLayout = (children: ReactNode) =>
     render(<UnderConstructionLayout>{children}</UnderConstructionLayout>);
 
 describe("UnderConstructionLayout", () => {
+    // HTML and body attributes
     it("renders html/body with lang and font variables", () => {
         renderLayout(<div>child</div>);
         const html = document.querySelector("html");
         const body = document.querySelector("body");
 
+        // ensure the language attribute & font variables are applied
         expect(html).toHaveAttribute("lang", "en");
         expect(body?.className).toContain("dmSansVar");
         expect(body?.className).toContain("tsukimiRoundedVar");
     });
 
+    // Layout structure and child rendering
     it("renders grid with Sidebar and puts children inside <main>", () => {
         renderLayout(<div data-testid='child' />);
 
-        // CSS modules are identity-mapped in tests, so these class names exist
+        //check that the grid container exists (css module class)
         const grid = document.querySelector(".layoutGrid");
         expect(grid).toBeInTheDocument();
 
+        // sidebar mock should be rendered inside the grid
         expect(screen.getByTestId("sidebar-mock")).toBeInTheDocument();
 
+        // verify main content container & check that it holds the children
         const main = document.querySelector("main.main");
         expect(main).toBeInTheDocument();
         expect(main).toContainElement(screen.getByTestId("child"));

--- a/src/app/under-construction/page.test.tsx
+++ b/src/app/under-construction/page.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * Under Construction Page Tests
+ *
+ * Developed with assistance from Claude AI and ChatGPT for:
+ * - Testing page layout and centering
+ * - Testing content rendering
+ * - Testing button functionality
+ * - Testing font styling
+ */
+
+import "@testing-library/jest-dom";
+import { render, screen } from "~tests/utils/custom-testing-library";
+import Page from "./page";
+
+const pushMock = jest.fn();
+jest.mock("next/navigation", () => ({
+    useRouter: () => ({
+        push: pushMock,
+    }),
+}));
+
+describe("Under Construction Page", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        render(<Page />);
+    });
+
+    describe("Rendering", () => {
+        it("should render the page content", () => {
+            const container = screen
+                .getByText(/This page is currently under construction/i)
+                .closest("div");
+            expect(container).toBeInTheDocument();
+        });
+
+        it("should display the main heading", () => {
+            const heading = screen.getByRole("heading", {
+                name: /This page is currently under construction/i,
+            });
+            expect(heading).toBeInTheDocument();
+        });
+
+        it("should display the subtext message", () => {
+            const message = screen.getByText(
+                /We're working hard to bring this page to life\. Check back soon!/i,
+            );
+            expect(message).toBeInTheDocument();
+        });
+
+        it("should render the back to sign-in button", () => {
+            const button = screen.getByRole("link", {
+                name: /Back to Sign-in/i,
+            });
+            expect(button).toBeInTheDocument();
+        });
+    });
+
+    describe("Button Functionality", () => {
+        it("button should link to home page", () => {
+            const button = screen.getByRole("link", {
+                name: /Back to Sign-in/i,
+            });
+            expect(button).toHaveAttribute("href", "/");
+        });
+
+        it("button should have Mantine button classes", () => {
+            const button = screen.getByRole("link", {
+                name: /Back to Sign-in/i,
+            });
+            expect(button.className).toContain("mantine-Button-root");
+        });
+
+        it("button should be clickable", () => {
+            const button = screen.getByRole("link", {
+                name: /Back to Sign-in/i,
+            });
+            expect(button).toBeEnabled();
+        });
+    });
+
+    describe("Typography & Styling", () => {
+        it("heading should have heading class", () => {
+            const heading = screen.getByRole("heading", {
+                name: /This page is currently under construction/i,
+            });
+            expect(heading).toHaveClass("heading");
+        });
+
+        it("paragraph should have text class", () => {
+            const paragraph = screen.getByText(
+                /We're working hard to bring this page to life\. Check back soon!/i,
+            );
+            expect(paragraph).toHaveClass("text");
+        });
+
+        it("container should have container class", () => {
+            const heading = screen.getByRole("heading", {
+                name: /This page is currently under construction/i,
+            });
+            const container = heading.closest(".container");
+            expect(container).toBeInTheDocument();
+        });
+
+        it("content wrapper should have content class", () => {
+            const heading = screen.getByRole("heading", {
+                name: /This page is currently under construction/i,
+            });
+            const content = heading.parentElement;
+            expect(content).toHaveClass("content");
+        });
+    });
+
+    describe("Content Structure", () => {
+        it("heading should be level 1", () => {
+            const heading = screen.getByRole("heading", {
+                level: 1,
+                name: /This page is currently under construction/i,
+            });
+            expect(heading).toBeInTheDocument();
+        });
+
+        it("heading should come before paragraph", () => {
+            const heading = screen.getByRole("heading", {
+                name: /This page is currently under construction/i,
+            });
+            const paragraph = screen.getByText(
+                /We're working hard to bring this page to life\. Check back soon!/i,
+            );
+            expect(
+                heading.compareDocumentPosition(paragraph) &
+                    Node.DOCUMENT_POSITION_FOLLOWING,
+            ).toBeTruthy();
+        });
+
+        it("button should come after paragraph", () => {
+            const paragraph = screen.getByText(
+                /We're working hard to bring this page to life\. Check back soon!/i,
+            );
+            const button = screen.getByRole("link", {
+                name: /Back to Sign-in/i,
+            });
+            expect(
+                paragraph.compareDocumentPosition(button) &
+                    Node.DOCUMENT_POSITION_FOLLOWING,
+            ).toBeTruthy();
+        });
+    });
+
+    describe("Accessibility", () => {
+        it("heading should have appropriate semantic level", () => {
+            const heading = screen.getByRole("heading", {
+                level: 1,
+                name: /This page is currently under construction/i,
+            });
+            expect(heading).toBeInTheDocument();
+        });
+
+        it("button should be keyboard accessible", () => {
+            const button = screen.getByRole("link", {
+                name: /Back to Sign-in/i,
+            });
+            button.focus();
+            expect(button).toHaveFocus();
+        });
+
+        it("button should have accessible text", () => {
+            const button = screen.getByRole("link", {
+                name: /Back to Sign-in/i,
+            });
+            expect(button).toHaveAccessibleName();
+        });
+
+        it("heading should be visible to screen readers", () => {
+            const heading = screen.getByRole("heading", {
+                name: /This page is currently under construction/i,
+            });
+            expect(heading).toBeVisible();
+        });
+    });
+
+    describe("Component Integration", () => {
+        it("all elements should be present in the DOM", () => {
+            expect(
+                screen.getByRole("heading", {
+                    name: /This page is currently under construction/i,
+                }),
+            ).toBeInTheDocument();
+
+            expect(
+                screen.getByText(
+                    /We're working hard to bring this page to life\. Check back soon!/i,
+                ),
+            ).toBeInTheDocument();
+
+            expect(
+                screen.getByRole("link", {
+                    name: /Back to Sign-in/i,
+                }),
+            ).toBeInTheDocument();
+        });
+
+        it("content should be properly nested", () => {
+            const heading = screen.getByRole("heading", {
+                name: /This page is currently under construction/i,
+            });
+            const contentDiv = heading.parentElement;
+            expect(contentDiv).toHaveClass("content");
+
+            const containerDiv = contentDiv?.parentElement;
+            expect(containerDiv).toHaveClass("container");
+        });
+    });
+});

--- a/src/components/sidebar.test.tsx
+++ b/src/components/sidebar.test.tsx
@@ -169,4 +169,20 @@ describe("Sidebar Component", () => {
             expect(screen.getByRole("complementary")).toHaveClass("open");
         });
     });
-});
+
+    // sidebar.test.tsx
+    it("should close sidebar when overlay is clicked", async () => {
+        const toggleBtn = screen.getByRole("button");
+
+        // open sidebar
+        await user.click(toggleBtn);
+        expect(screen.getByRole("complementary")).toHaveClass("open");
+
+        // click overlay (now guaranteed to exist)
+        const overlay = screen.getByTestId("sidebar-overlay");
+        await user.click(overlay);
+
+        // sidebar should be closed
+        expect(screen.getByRole("complementary")).not.toHaveClass("open");
+    });
+}); //end main describe (Sidebar)

--- a/src/components/sidebar.test.tsx
+++ b/src/components/sidebar.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * Sidebar Navigation Component Tests
+ *
+ * Developed with assistance from Claude AI and ChatGPT for:
+ * - Testing responsive sidebar behavior
+ * - Testing mobile menu toggle
+ * - Testing navigation links
+ * - Testing logo visibility
+ *
+ * Testing patterns and best practices from:
+ * - https://testing-library.com/docs/react-testing-library/intro
+ * - https://testing-library.com/docs/queries/about
+ * - also referenced "signup/vet/page.test.tsx"
+ */
+
+import "@testing-library/jest-dom";
+import userEvent from "@testing-library/user-event";
+import { fireEvent, render, screen } from "~tests/utils/custom-testing-library";
+import Sidebar from "./sidebar";
+
+describe("Sidebar Component", () => {
+    let user: ReturnType<typeof userEvent.setup>;
+
+    beforeEach(() => {
+        user = userEvent.setup(); // create fresh event simulator
+        render(<Sidebar />); // render the Sidebar component to the virtual DOM
+    });
+
+    describe("Rendering Side NavBar", () => {
+        it("should render the sidebar", () => {
+            const sidebar = screen.getByRole("complementary");
+            expect(sidebar).toBeInTheDocument();
+        });
+
+        it("should render the QDog logo", () => {
+            const logo = screen.getByAltText("QDog Logo");
+            expect(logo).toBeInTheDocument();
+        });
+
+        it("should render all navigation links", () => {
+            expect(screen.getByText("Dashboard")).toBeInTheDocument();
+            expect(screen.getByText("My Pets")).toBeInTheDocument();
+            expect(screen.getByText("Appointments")).toBeInTheDocument();
+            expect(screen.getByText("Pet Diary")).toBeInTheDocument();
+            expect(screen.getByText("Messages")).toBeInTheDocument();
+        });
+    });
+
+    describe("Navigation Links", () => {
+        it("all nav links should link to under-construction page", () => {
+            const navLinks = screen.getAllByText(
+                /Dashboard|My Pets|Appointments|Pet Diary|Messages/,
+            );
+            navLinks.forEach((link) => {
+                expect(link.closest("a")).toHaveAttribute(
+                    "href",
+                    "/under-construction",
+                );
+            });
+        });
+
+        it("logo link should navigate to home", () => {
+            const logoLink = screen.getByAltText("QDog Logo").closest("a");
+            expect(logoLink).toHaveAttribute("href", "/");
+        });
+
+        it("nav links should have navLink class styling", () => {
+            const dashboardLink = screen.getByText("Dashboard");
+            expect(dashboardLink.closest("a")?.className).toContain("navLink");
+        });
+    });
+
+    // Desktop Tests
+    describe("Desktop View", () => {
+        it("logo should be visible on desktop", () => {
+            const logo = screen.getByAltText("QDog Logo");
+            expect(logo).toBeVisible();
+        });
+
+        it("toggle button should not be visible on desktop", () => {
+            const toggleBtn = screen.queryByRole("button");
+            if (toggleBtn) {
+                expect(toggleBtn).toHaveClass("toggleBtn");
+            }
+        });
+
+        it("all nav links should be visible on desktop", () => {
+            expect(screen.getByText("Dashboard")).toBeVisible();
+            expect(screen.getByText("My Pets")).toBeVisible();
+            expect(screen.getByText("Appointments")).toBeVisible();
+            expect(screen.getByText("Pet Diary")).toBeVisible();
+            expect(screen.getByText("Messages")).toBeVisible();
+        });
+    });
+
+    // Mobile Tests
+    describe("Mobile View - Toggle Functionality", () => {
+        it("toggle button should open and close sidebar", async () => {
+            const toggleBtn = screen.getByRole("button");
+
+            // open sidebar
+            await user.click(toggleBtn);
+            let sidebar = screen.getByRole("complementary");
+            expect(sidebar).toHaveClass("open");
+
+            // close sidebar
+            await user.click(toggleBtn);
+            sidebar = screen.getByRole("complementary");
+            expect(sidebar).not.toHaveClass("open");
+        });
+
+        it("logo should be hidden on mobile", () => {
+            const logo = screen.getByAltText("QDog Logo");
+            expect(logo).toBeInTheDocument();
+        });
+
+        it("should close sidebar when overlay is clicked", async () => {
+            const toggleBtn = screen.getByRole("button");
+
+            // open sidebar
+            await user.click(toggleBtn);
+            expect(screen.getByRole("complementary")).toHaveClass("open");
+
+            // find and click overlay
+            const overlay = document.querySelector(
+                "[data-testid='sidebar-overlay']",
+            );
+            if (overlay) {
+                await user.click(overlay);
+                expect(screen.getByRole("complementary")).not.toHaveClass(
+                    "open",
+                );
+            }
+        });
+
+        it("should display navigation links when sidebar is open", async () => {
+            const toggleBtn = screen.getByRole("button");
+
+            await user.click(toggleBtn);
+
+            expect(screen.getByText("Dashboard")).toBeVisible();
+            expect(screen.getByText("My Pets")).toBeVisible();
+            expect(screen.getByText("Appointments")).toBeVisible();
+            expect(screen.getByText("Pet Diary")).toBeVisible();
+            expect(screen.getByText("Messages")).toBeVisible();
+        });
+    });
+
+    // Accessibility Tests
+    describe("Accessibility", () => {
+        it("sidebar should be a complementary landmark", () => {
+            const sidebar = screen.getByRole("complementary");
+            expect(sidebar).toBeInTheDocument();
+        });
+
+        it("nav links should be keyboard accessible", async () => {
+            const firstLink = screen.getByText("Dashboard").closest("a");
+            firstLink?.focus();
+            expect(firstLink).toHaveFocus();
+        });
+
+        it("toggle button should be keyboard accessible", async () => {
+            const toggleBtn = screen.getByRole("button");
+            toggleBtn.focus();
+            expect(toggleBtn).toHaveFocus();
+
+            // simulate keyboard entry
+            await user.keyboard("{Enter}");
+            expect(screen.getByRole("complementary")).toHaveClass("open");
+        });
+    });
+});

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -37,6 +37,7 @@ export default function Sidebar() {
             {/* Sidebar overlay for mobile - closes sidebar when clicked */}
             {isOpen && (
                 <div
+                    data-testid='sidebar-overlay'
                     onClick={() => setIsOpen(false)}
                     className={styles.overlay}
                 />


### PR DESCRIPTION
**Summary**
Added comprehensive frontend test suites for the sidebar navigation and under-construction page components.

**Changes**
Created `sidebar.test.tsx`, `page.test.tsx` & `layout.test.tsx` with 39 tests total

## Test Results
All tests passing
<img width="775" height="169" alt="Screenshot 2025-10-14 at 10 03 28 PM" src="https://github.com/user-attachments/assets/d3468720-9595-49e7-afca-d1914880186f" />
