### PR TITLE
chore[QDOG-116]: address tech debt for new pet page

### DIFF
--- a/src/app/owner/pets/create/page.module.scss
+++ b/src/app/owner/pets/create/page.module.scss
@@ -14,7 +14,6 @@
     }
 
     h1 {
-        font-family: var(--font-tsukimi_rounded), var(--font-dm_sans), Arial;
         font-size: 2.5rem;
     }
 
@@ -51,7 +50,6 @@
         display: flex;
         position: relative;
         overflow: hidden;
-
         background-color: var(--mantine-color-gray-3);
     }
 

--- a/src/app/owner/pets/create/page.module.scss
+++ b/src/app/owner/pets/create/page.module.scss
@@ -96,11 +96,17 @@
     justify-content: flex-end;
 
     padding-top: 2rem;
-    padding-bottom: 2rem;
+
     padding-left: 2rem;
 }
 
 .right_content {
     justify-content: flex-end;
     flex-grow: inherit;
+}
+
+.error_message {
+    color: red;
+    justify-self: end;
+    padding-bottom: 2rem;
 }

--- a/src/app/owner/pets/create/page.module.scss
+++ b/src/app/owner/pets/create/page.module.scss
@@ -14,7 +14,6 @@
     }
 
     h1 {
-        text-align: center;
         font-family: var(--font-tsukimi_rounded), var(--font-dm_sans), Arial;
         font-size: 2.5rem;
     }

--- a/src/app/owner/pets/create/page.module.scss
+++ b/src/app/owner/pets/create/page.module.scss
@@ -9,12 +9,13 @@
     background-color: #f9f9f9;
 
     main {
-        text-align: center;
         max-width: 1000px;
         width: 100%;
     }
 
     h1 {
+        text-align: center;
+        font-family: var(--font-tsukimi_rounded), var(--font-dm_sans), Arial;
         font-size: 2.5rem;
     }
 
@@ -102,7 +103,6 @@
 
 .right_content {
     justify-content: flex-end;
-    flex-grow: inherit;
 }
 
 .error_message {

--- a/src/app/owner/pets/create/page.test.tsx
+++ b/src/app/owner/pets/create/page.test.tsx
@@ -74,7 +74,6 @@ describe("New Pet page", () => {
     let breedOrVariety: HTMLElement;
     let birthDate: HTMLElement;
     let estimatedBirthDateToggle: HTMLElement;
-    let adoptionDate: HTMLElement;
     let sex: HTMLElement;
     let spayedOrNeutered: HTMLElement;
     let user: ReturnType<typeof userEvent.setup>;
@@ -95,7 +94,6 @@ describe("New Pet page", () => {
             breedOrVariety,
             birthDate,
             estimatedBirthDateToggle,
-            adoptionDate,
             sex,
             spayedOrNeutered,
         } = await getNewPetElements());

--- a/src/app/owner/pets/create/page.test.tsx
+++ b/src/app/owner/pets/create/page.test.tsx
@@ -187,7 +187,7 @@ describe("New Pet page", () => {
             await user.click(screen.getByRole("button", { name: /save/i }));
 
             async () =>
-                expect(pushMock).toHaveBeenCalledWith("/dashboard/owner");
+                expect(pushMock).toHaveBeenCalledWith("/owner/dashboard");
         });
     });
 
@@ -278,7 +278,7 @@ describe("New Pet page", () => {
             await user.click(screen.getByRole("button", { name: /save/i }));
 
             async () =>
-                expect(pushMock).toHaveBeenCalledWith("/dashboard/owner");
+                expect(pushMock).toHaveBeenCalledWith("/owner/dashboard");
         });
     });
 
@@ -329,7 +329,7 @@ describe("New Pet page", () => {
             await user.click(screen.getByRole("button", { name: /save/i }));
 
             async () =>
-                expect(pushMock).toHaveBeenCalledWith("/dashboard/owner");
+                expect(pushMock).toHaveBeenCalledWith("/owner/dashboard");
         });
     });
 
@@ -386,7 +386,7 @@ describe("New Pet page", () => {
             await user.click(screen.getByRole("button", { name: /save/i }));
 
             async () =>
-                expect(pushMock).toHaveBeenCalledWith("/dashboard/owner");
+                expect(pushMock).toHaveBeenCalledWith("/owner/dashboard");
         });
     });
 
@@ -473,7 +473,7 @@ describe("New Pet page", () => {
             await user.click(screen.getByRole("button", { name: /save/i }));
 
             async () =>
-                expect(pushMock).toHaveBeenCalledWith("/dashboard/owner");
+                expect(pushMock).toHaveBeenCalledWith("/owner/dashboard");
         });
     });
 
@@ -564,7 +564,7 @@ describe("New Pet page", () => {
             await user.click(screen.getByRole("button", { name: /save/i }));
 
             async () =>
-                expect(pushMock).toHaveBeenCalledWith("/dashboard/owner");
+                expect(pushMock).toHaveBeenCalledWith("/owner/dashboard");
         });
     });
 

--- a/src/app/owner/pets/create/page.test.tsx
+++ b/src/app/owner/pets/create/page.test.tsx
@@ -15,7 +15,6 @@ import {
     DEFAULT_SEX,
     DEFAULT_SPAYED_OR_NEUTERED,
     DEFAULT_BIRTH_DATE,
-    DEFAULT_ADOPTION_DATE,
     DEFAULT_NAME,
 } from "~tests/utils/defaults";
 
@@ -626,47 +625,6 @@ describe("New Pet page", () => {
         it("has dialog role attributes", () => {
             expect(birthDate).toHaveAttribute("aria-haspopup", "dialog");
             expect(birthDate).toHaveAttribute("aria-expanded", "false");
-        });
-    });
-
-    describe("Adoption Date field", () => {
-        beforeEach(async () => {
-            await fillNewPetDefaults();
-            await pickSelectDefaults({
-                user,
-                animalGroupEl: animalGroup,
-                sexEl: sex,
-                spayedEl: spayedOrNeutered,
-                animalGroupText: DEFAULT_ANIMAL_GROUP,
-                sexText: DEFAULT_SEX,
-                spayedText: DEFAULT_SPAYED_OR_NEUTERED,
-            });
-        });
-
-        it("is present", () => {
-            expect(adoptionDate).toBeInTheDocument();
-        });
-
-        it("has correct label", () => {
-            expect(screen.getByText(/date of adoption/i)).toBeInTheDocument();
-        });
-
-        it("does not have required attribute (optional field)", () => {
-            expect(adoptionDate).not.toHaveAttribute("required");
-        });
-
-        it("can be focused and interacted with", async () => {
-            await user.click(adoptionDate);
-            expect(adoptionDate).toHaveFocus();
-        });
-
-        it("displays default date value", () => {
-            expect(adoptionDate).toHaveTextContent(DEFAULT_ADOPTION_DATE);
-        });
-
-        it("has correct dialog role attributes", () => {
-            expect(adoptionDate).toHaveAttribute("aria-haspopup", "dialog");
-            expect(adoptionDate).toHaveAttribute("aria-expanded", "false");
         });
     });
 });

--- a/src/app/owner/pets/create/page.tsx
+++ b/src/app/owner/pets/create/page.tsx
@@ -193,7 +193,8 @@ export default function NewPet() {
                                 key={form.key("name")}
                                 {...form.getInputProps("name")}
                             />
-
+                        </div>
+                        <div className={styles.right_content}>
                             <Select
                                 data={sexOptions}
                                 {...form.getInputProps("sex")}
@@ -202,8 +203,7 @@ export default function NewPet() {
                                 placeholder='Please select a sex'
                                 required
                             />
-                        </div>
-                        <div className={styles.right_content}>
+
                             <Select
                                 data={basicOptions}
                                 {...form.getInputProps("spayedOrNeutered")}

--- a/src/app/owner/pets/create/page.tsx
+++ b/src/app/owner/pets/create/page.tsx
@@ -143,7 +143,7 @@ export default function NewPet() {
             const pet = new Pet(petJSON);
             if (user?.id != null) {
                 await PetsAPI.createPet(user.id, pet);
-                router.push("/dashboard/owner");
+                router.push("/owner/dashboard");
             } else {
                 setError("You cannot make a pet without being logged in.");
             }

--- a/src/app/owner/pets/create/page.tsx
+++ b/src/app/owner/pets/create/page.tsx
@@ -126,22 +126,24 @@ export default function NewPet() {
     const handleSubmit = async (values: typeof form.values) => {
         try {
             setError("");
-            const estimatedDate: Date = estimatedBirthDate
-                ? values.birthdate
-                : todayDate;
-
-            let sterileStatus: SterileStatus;
-            if (values.spayedOrNeutered == "Yes") {
-                sterileStatus = SterileStatus.sterile;
-            } else if (values.spayedOrNeutered == "No") {
-                sterileStatus = SterileStatus.nonsterile;
-            } else {
-                sterileStatus = SterileStatus.unknown;
-            }
             const user = JSON.parse(localStorage.getItem("currentUser"));
-            const petJSON = { ...values, sterileStatus: sterileStatus };
-            const pet = new Pet(petJSON);
+
             if (user?.id != null) {
+                let sterileStatus: SterileStatus;
+                if (values.spayedOrNeutered == "Yes") {
+                    sterileStatus = SterileStatus.sterile;
+                } else if (values.spayedOrNeutered == "No") {
+                    sterileStatus = SterileStatus.nonsterile;
+                } else {
+                    sterileStatus = SterileStatus.unknown;
+                }
+
+                const petJSON = {
+                    ...values,
+                    sterileStatus: sterileStatus,
+                    estimatedBirthdate: estimatedBirthDate,
+                };
+                const pet = new Pet(petJSON);
                 await PetsAPI.createPet(user.id, pet);
                 router.push("/owner/dashboard");
             } else {

--- a/src/app/owner/pets/create/page.tsx
+++ b/src/app/owner/pets/create/page.tsx
@@ -40,6 +40,8 @@ export default function NewPet() {
     const [previewUrl, setPreviewUrl] = useState<string>(placeholderImage.src);
     const router = useRouter();
 
+    const [error, setError] = useState("");
+
     const form = useForm({
         mode: "uncontrolled",
         initialValues: {
@@ -125,13 +127,7 @@ export default function NewPet() {
 
     const handleSubmit = async (values: typeof form.values) => {
         try {
-            const newBirthDate: Date = estimatedBirthDate
-                ? defaultDate
-                : values.birthdate;
-            const estimatedDate: Date = estimatedBirthDate
-                ? values.birthdate
-                : defaultDate;
-
+            setError("");
             let sterileStatus;
             if (values.spayedOrNeutered == "Yes") {
                 sterileStatus = "STERILE";
@@ -143,12 +139,14 @@ export default function NewPet() {
             const user = JSON.parse(localStorage.getItem("currentUser"));
             const petJSON = { ...values, sterileStatus: sterileStatus };
             const pet = new Pet(petJSON);
-            if (user.id != null) {
+            if (user?.id != null) {
                 await PetsAPI.createPet(user.id, pet);
                 router.push("/dashboard/owner");
+            } else {
+                setError("You cannot make a pet without being logged in.");
             }
         } catch (error) {
-            //TODO: add error message
+            setError("You cannot make a pet without being logged in.");
         }
     };
 
@@ -272,6 +270,7 @@ export default function NewPet() {
                             Save
                         </Button>
                     </div>
+                    <p className={styles.error_message}>{error}</p>
                 </form>
             </main>
         </div>

--- a/src/app/owner/pets/create/page.tsx
+++ b/src/app/owner/pets/create/page.tsx
@@ -4,12 +4,8 @@ import { Box, Button, Group, Select, Switch, TextInput } from "@mantine/core";
 import { useEffect, useState } from "react";
 import { isNotEmpty, useForm } from "@mantine/form";
 import { DatePickerInput } from "@mantine/dates";
-import {
-    todayDate,
-    sexOptions,
-    animalGroupOptions,
-    basicOptions,
-} from "~data/constants";
+import { todayDate, basicOptions } from "~data/constants";
+import { animalGroupOptions, sexOptions } from "~data/pets/constants";
 import { validateImage } from "~util/validation/validate-new-pet";
 import { urlToFile } from "~util/file-handling";
 import {

--- a/src/app/owner/pets/create/page.tsx
+++ b/src/app/owner/pets/create/page.tsx
@@ -21,7 +21,7 @@ import styles from "./page.module.scss";
 import placeholderImage from "~public/placeholder.jpg"; // https://media.istockphoto.com/id/1147544807/vector/thumbnail-image-vector-graphic.jpg?s=612x612&w=0&k=20&c=rnCKVbdxqkjlcs3xH87-9gocETqpspHFXu5dIGB4wuM=
 import { useFileDialog } from "@mantine/hooks";
 import { PetsAPI } from "src/api/petsAPI";
-import { Pet } from "src/models/pet";
+import { Pet, SterileStatus } from "src/models/pet";
 import { useRouter } from "next/navigation";
 
 /**
@@ -128,13 +128,20 @@ export default function NewPet() {
     const handleSubmit = async (values: typeof form.values) => {
         try {
             setError("");
-            let sterileStatus;
+            const newBirthDate: Date = estimatedBirthDate
+                ? defaultDate
+                : values.birthdate;
+            const estimatedDate: Date = estimatedBirthDate
+                ? values.birthdate
+                : defaultDate;
+
+            let sterileStatus: SterileStatus;
             if (values.spayedOrNeutered == "Yes") {
-                sterileStatus = "STERILE";
+                sterileStatus = SterileStatus.sterile;
             } else if (values.spayedOrNeutered == "No") {
-                sterileStatus = "NOT_STERILE";
+                sterileStatus = SterileStatus.nonsterile;
             } else {
-                sterileStatus = "UNKNOWN";
+                sterileStatus = SterileStatus.unknown;
             }
             const user = JSON.parse(localStorage.getItem("currentUser"));
             const petJSON = { ...values, sterileStatus: sterileStatus };

--- a/src/app/owner/pets/create/page.tsx
+++ b/src/app/owner/pets/create/page.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 import { isNotEmpty, useForm } from "@mantine/form";
 import { DatePickerInput } from "@mantine/dates";
 import {
-    defaultDate,
+    todayDate,
     sexOptions,
     animalGroupOptions,
     basicOptions,
@@ -50,8 +50,7 @@ export default function NewPet() {
             animalGroup: "",
             species: "",
             breed: "",
-            birthdate: defaultDate,
-            adoptionDate: defaultDate,
+            birthdate: todayDate,
             sex: "",
             spayedOrNeutered: "",
         },
@@ -67,7 +66,6 @@ export default function NewPet() {
             species: validateRequiredStringValue,
             breed: validateRequiredStringValue,
             birthdate: validateRequiredDateValue,
-            adoptionDate: validateOptionalDateValue,
         },
     });
 
@@ -128,12 +126,9 @@ export default function NewPet() {
     const handleSubmit = async (values: typeof form.values) => {
         try {
             setError("");
-            const newBirthDate: Date = estimatedBirthDate
-                ? defaultDate
-                : values.birthdate;
             const estimatedDate: Date = estimatedBirthDate
                 ? values.birthdate
-                : defaultDate;
+                : todayDate;
 
             let sterileStatus: SterileStatus;
             if (values.spayedOrNeutered == "Yes") {
@@ -246,6 +241,7 @@ export default function NewPet() {
                                     required
                                     key={form.key("birthdate")}
                                     error={form.errors.birthdate}
+                                    clearable={true}
                                     {...form.getInputProps("birthdate")}
                                 ></DatePickerInput>
                                 <Switch
@@ -259,12 +255,6 @@ export default function NewPet() {
                                     label='Estimated'
                                 />
                             </div>
-                            <DatePickerInput
-                                label='Date of Adoption'
-                                key={form.key("adoptionDate")}
-                                error={form.errors.adoptionDate}
-                                {...form.getInputProps("adoptionDate")}
-                            ></DatePickerInput>
                         </div>
                     </div>
                     <div className={styles.bottom_content}>

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -24,7 +24,7 @@ export const basicOptions: string[] = [
     "Not Applicable",
 ];
 
-export const defaultDate: Date = new Date(0);
+export const defaultDate: Date = new Date();
 
 export const todayDate: Date = new Date();
 

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -24,7 +24,7 @@ export const basicOptions: string[] = [
     "Not Applicable",
 ];
 
-export const defaultDate: Date = new Date();
+export const defaultDate: Date = new Date(0);
 
 export const todayDate: Date = new Date();
 

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -27,17 +27,3 @@ export const basicOptions: string[] = [
 export const defaultDate: Date = new Date(0);
 
 export const todayDate: Date = new Date();
-
-export const animalGroupOptions: string[] = [
-    "Small mammal (e.g. cat, rabbit, and mouse)",
-    "Farm (e.g. chicken, pig, and cow)",
-    "Equine (e.g. horse)",
-    "Bird",
-    "Reptile",
-    "Amphibian",
-    "Fish",
-    "Invertebrate",
-    "Other",
-];
-
-export const sexOptions: string[] = ["Male", "Female", "Unknown"];

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -29,7 +29,7 @@ export const defaultDate: Date = new Date(0);
 export const todayDate: Date = new Date();
 
 export const animalGroupOptions: string[] = [
-    "Small animal (e.g. cat, rabbit, and mouse)",
+    "Small mammal (e.g. cat, rabbit, and mouse)",
     "Farm (e.g. chicken, pig, and cow)",
     "Equine (e.g. horse)",
     "Bird",

--- a/src/data/pets/constants.ts
+++ b/src/data/pets/constants.ts
@@ -1,0 +1,13 @@
+export const animalGroupOptions: string[] = [
+    "Small mammal (e.g. cat, rabbit, and mouse)",
+    "Farm (e.g. chicken, pig, and cow)",
+    "Equine (e.g. horse)",
+    "Bird",
+    "Reptile",
+    "Amphibian",
+    "Fish",
+    "Invertebrate",
+    "Other",
+];
+
+export const sexOptions: string[] = ["Male", "Female", "Unknown"];

--- a/src/models/pet.ts
+++ b/src/models/pet.ts
@@ -1,3 +1,8 @@
+export enum SterileStatus {
+    sterile = "STERILE",
+    nonsterile = "NON_STERILE",
+    unknown = "UNKNOWN",
+}
 export class Pet {
     public readonly name: string;
     public readonly breed: string;
@@ -5,7 +10,7 @@ export class Pet {
     public readonly species: string;
     public readonly id: number;
     public readonly birthdate: string;
-    public readonly sterileStatus: string;
+    public readonly sterileStatus: SterileStatus;
 
     constructor(JSON) {
         Object.assign(this, JSON);

--- a/src/models/pet.ts
+++ b/src/models/pet.ts
@@ -10,7 +10,9 @@ export class Pet {
     public readonly species: string;
     public readonly id: number;
     public readonly birthdate: string;
+    public readonly estimatedBirthdate: boolean;
     public readonly sterileStatus: SterileStatus;
+    public readonly animalGroup: string;
 
     constructor(JSON) {
         Object.assign(this, JSON);

--- a/src/tests/utils/defaults.ts
+++ b/src/tests/utils/defaults.ts
@@ -1,4 +1,4 @@
-import { defaultDate } from "~data/constants";
+import { defaultDate, todayDate } from "~data/constants";
 import dayjs from "dayjs";
 
 /**
@@ -20,5 +20,4 @@ export const DEFAULT_SEX = "Male";
 export const DEFAULT_SPAYED_OR_NEUTERED = "Yes";
 export const DEFAULT_SPECIES = "Parrot";
 export const DEFAULT_BREED_OR_VARIETY = "Macaw";
-export const DEFAULT_BIRTH_DATE = dayjs(defaultDate).format("MMMM D, YYYY");
-export const DEFAULT_ADOPTION_DATE = dayjs(defaultDate).format("MMMM D, YYYY");
+export const DEFAULT_BIRTH_DATE = dayjs(todayDate).format("MMMM D, YYYY");


### PR DESCRIPTION
Updates to add new pet page:

- displays error message when the user is not logged in and attempts to send a request.
- displays error message when it fails, right now I can only assume it would fail due to an invalid ownerID, so the error message reflects that
- Added sterile status enum to pet model that ensures it matches the back end
- Added estimatedBirthdate and animalGroup to pet model as we want to add it to the back end
- updated birthday to default to "today" and updated tests to reflect that as well
- Removed adoption date from fields as its not in the back end
- updated css to better match design 
- moved pet related constants to a new file

<img width="1889" height="939" alt="image" src="https://github.com/user-attachments/assets/4114c730-4f42-4332-9fa7-ab8f5cb28640" />
