### PR TITLE
hotfix(QDOG-102): missing sign up page styles

### DIFF
--- a/src/app/auth/login/page.test.tsx
+++ b/src/app/auth/login/page.test.tsx
@@ -76,7 +76,7 @@ describe("Login page (src/app/page.tsx)", () => {
     it("sign up link points to /signup/owner by default", () => {
         setup();
         const link = screen.getByRole("link", { name: /sign up!/i });
-        expect(link).toHaveAttribute("href", "/signup/owner");
+        expect(link).toHaveAttribute("href", "/auth/sign-up/owner");
     });
 
     it("switching to Veterinarian updates the sign up link to /signup/vet", async () => {
@@ -87,10 +87,10 @@ describe("Login page (src/app/page.tsx)", () => {
         await user.click(vetTab);
 
         const link = screen.getByRole("link", { name: /sign up!/i });
-        expect(link).toHaveAttribute("href", "/signup/vet");
+        expect(link).toHaveAttribute("href", "/auth/sign-up/vet");
     });
 
-    it("submits and routes to /dashboard/owner when Pet Owner is selected", async () => {
+    it("submits and routes to /owner/dashboard when Pet Owner is selected", async () => {
         setup();
         const user = userEvent.setup();
 
@@ -102,11 +102,11 @@ describe("Login page (src/app/page.tsx)", () => {
         await user.click(screen.getByRole("button", { name: /login/i }));
 
         await waitFor(() => {
-            expect(push).toHaveBeenCalledWith("/dashboard/owner");
+            expect(push).toHaveBeenCalledWith("/owner/dashboard");
         });
     });
 
-    it("submits and routes to /dashboard/vet when Veterinarian is selected", async () => {
+    it("submits and routes to /vet/dashboard when Veterinarian is selected", async () => {
         setup();
         const user = userEvent.setup();
 
@@ -121,7 +121,7 @@ describe("Login page (src/app/page.tsx)", () => {
         await user.click(screen.getByRole("button", { name: /login/i }));
 
         await waitFor(() => {
-            expect(push).toHaveBeenCalledWith("/dashboard/vet");
+            expect(push).toHaveBeenCalledWith("/vet/dashboard");
         });
     });
 

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -58,11 +58,11 @@ export default function LoginPage() {
             if (selectedUser === vet) {
                 const vet = await VetsAPI.vetLogin(values);
                 localStorage.setItem("currentUser", JSON.stringify(vet));
-                router.push("/dashboard/vet");
+                router.push("/vet/dashboard");
             } else {
                 const owner = await OwnersAPI.ownerLogin(values);
                 localStorage.setItem("currentUser", JSON.stringify(owner));
-                router.push("/dashboard/owner");
+                router.push("/owner/dashboard");
             }
         } catch (error) {
             setErrorMessage("Invalid Login. Please try again.");
@@ -118,7 +118,7 @@ export default function LoginPage() {
                             </a>
                             <p>
                                 Don't have an account yet?{" "}
-                                <Link href={`/signup/${selectedUser}`}>
+                                <Link href={`/auth/sign-up/${selectedUser}`}>
                                     Sign up!
                                 </Link>
                             </p>

--- a/src/app/auth/sign-up/layout.module.scss
+++ b/src/app/auth/sign-up/layout.module.scss
@@ -1,0 +1,30 @@
+@import '../../globals.scss';
+
+.layout {
+    display: grid;
+    grid-template: 1fr / auto;
+    padding: 64px 32px;
+
+    main {
+        width: 100%;
+        max-width: 360px;
+
+        display: grid;
+        grid-template: auto 1fr / 1fr;
+        row-gap: 50px;
+
+        margin: 0 auto;
+
+        h1 {
+            font-family:
+                var(--font-tsukimi_rounded), var(--font-dm_sans), Arial;
+            text-align: center;
+        }
+
+        form {
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
+        }
+    }
+}

--- a/src/app/auth/sign-up/layout.tsx
+++ b/src/app/auth/sign-up/layout.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import styles from "./layout.module.scss";
+
+export default function SignupLayout({
+    children,
+}: {
+    children: React.ReactNode;
+}) {
+    return (
+        <div className={styles.layout}>
+            <main>{children}</main>
+        </div>
+    );
+}

--- a/src/app/layout.module.scss
+++ b/src/app/layout.module.scss
@@ -15,18 +15,9 @@
     min-height: 100vh;
 }
 
-/* Main content area */
-.main {
-    padding: 16px;
-}
-
 .layout {
     display: flex;
     min-height: 100vh;
-}
-
-.main {
-    flex: 1; /* take full width when sidebar is hidden */
 }
 
 /* MOBILE STYLES - screens 768px and below */

--- a/src/app/under-construction/page.module.scss
+++ b/src/app/under-construction/page.module.scss
@@ -44,6 +44,13 @@
     line-height: 1.6;
 }
 
+.button_group {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    gap: 16px;
+}
+
 /* Responsive design for mobile */
 @media (max-width: 768px) {
     .heading {
@@ -54,5 +61,10 @@
     .text {
         font-size: 16px;
         margin-bottom: 25px;
+    }
+
+    .button_group {
+        flex-direction: column;
+        gap: 8px;
     }
 }

--- a/src/app/under-construction/page.test.tsx
+++ b/src/app/under-construction/page.test.tsx
@@ -13,9 +13,11 @@ import { render, screen } from "~tests/utils/custom-testing-library";
 import Page from "./page";
 
 const pushMock = jest.fn();
+const backMock = jest.fn();
 jest.mock("next/navigation", () => ({
     useRouter: () => ({
         push: pushMock,
+        back: backMock,
     }),
 }));
 
@@ -53,28 +55,42 @@ describe("Under Construction Page", () => {
             });
             expect(button).toBeInTheDocument();
         });
+
+        it("should render the back to previous button", () => {
+            const button = screen.getByRole("button", {
+                name: /Back to Previous/i,
+            });
+            expect(button).toBeInTheDocument();
+        });
     });
 
     describe("Button Functionality", () => {
-        it("button should link to home page", () => {
+        it("back to sign-in should link to home page", () => {
             const button = screen.getByRole("link", {
                 name: /Back to Sign-in/i,
             });
             expect(button).toHaveAttribute("href", "/");
         });
 
-        it("button should have Mantine button classes", () => {
-            const button = screen.getByRole("link", {
-                name: /Back to Sign-in/i,
+        it("back to previous should call router.back when clicked", async () => {
+            const button = screen.getByRole("button", {
+                name: /Back to Previous/i,
             });
-            expect(button.className).toContain("mantine-Button-root");
+            expect(button).toBeInTheDocument();
+            button.click();
+            expect(backMock).toHaveBeenCalled();
         });
 
-        it("button should be clickable", () => {
-            const button = screen.getByRole("link", {
+        it("buttons should be clickable", () => {
+            const backToSignin = screen.getByRole("link", {
                 name: /Back to Sign-in/i,
             });
-            expect(button).toBeEnabled();
+            const backToPrevious = screen.getByRole("button", {
+                name: /Back to Previous/i,
+            });
+
+            expect(backToSignin).toBeEnabled();
+            expect(backToPrevious).toBeEnabled();
         });
     });
 
@@ -155,19 +171,30 @@ describe("Under Construction Page", () => {
             expect(heading).toBeInTheDocument();
         });
 
-        it("button should be keyboard accessible", () => {
-            const button = screen.getByRole("link", {
+        it("buttons should be keyboard accessible", () => {
+            const backToSignin = screen.getByRole("link", {
                 name: /Back to Sign-in/i,
             });
-            button.focus();
-            expect(button).toHaveFocus();
+            backToSignin.focus();
+            expect(backToSignin).toHaveFocus();
+
+            const backToPrevious = screen.getByRole("button", {
+                name: /Back to Previous/i,
+            });
+            backToPrevious.focus();
+            expect(backToPrevious).toHaveFocus();
         });
 
-        it("button should have accessible text", () => {
-            const button = screen.getByRole("link", {
+        it("buttons should have accessible text", () => {
+            const backToSignin = screen.getByRole("link", {
                 name: /Back to Sign-in/i,
             });
-            expect(button).toHaveAccessibleName();
+            expect(backToSignin).toHaveAccessibleName();
+
+            const backToPrevious = screen.getByRole("button", {
+                name: /Back to Previous/i,
+            });
+            expect(backToPrevious).toHaveAccessibleName();
         });
 
         it("heading should be visible to screen readers", () => {
@@ -175,39 +202,6 @@ describe("Under Construction Page", () => {
                 name: /This page is currently under construction/i,
             });
             expect(heading).toBeVisible();
-        });
-    });
-
-    describe("Component Integration", () => {
-        it("all elements should be present in the DOM", () => {
-            expect(
-                screen.getByRole("heading", {
-                    name: /This page is currently under construction/i,
-                }),
-            ).toBeInTheDocument();
-
-            expect(
-                screen.getByText(
-                    /We're working hard to bring this page to life\. Check back soon!/i,
-                ),
-            ).toBeInTheDocument();
-
-            expect(
-                screen.getByRole("link", {
-                    name: /Back to Sign-in/i,
-                }),
-            ).toBeInTheDocument();
-        });
-
-        it("content should be properly nested", () => {
-            const heading = screen.getByRole("heading", {
-                name: /This page is currently under construction/i,
-            });
-            const contentDiv = heading.parentElement;
-            expect(contentDiv).toHaveClass("content");
-
-            const containerDiv = contentDiv?.parentElement;
-            expect(containerDiv).toHaveClass("container");
         });
     });
 });

--- a/src/app/under-construction/page.tsx
+++ b/src/app/under-construction/page.tsx
@@ -12,11 +12,18 @@
 import { Button } from "@mantine/core";
 import Link from "next/link";
 import styles from "./page.module.scss";
+import { useRouter } from "next/navigation";
 
 /**
  * Dummy page for unfinished routes
  */
 export default function Page() {
+    const router = useRouter();
+
+    const handleBack = () => {
+        router.back();
+    };
+
     return (
         <div className={styles.container}>
             <div className={styles.content}>
@@ -27,15 +34,25 @@ export default function Page() {
                     We're working hard to bring this page to life. Check back
                     soon!
                 </p>
-                <Button
-                    component={Link}
-                    href='/'
-                    variant='light'
-                    mt='md'
-                    color='blue'
-                >
-                    Back to Sign-in
-                </Button>
+                <div className={styles.button_group}>
+                    <Button
+                        variant='light'
+                        mt='md'
+                        color='blue'
+                        onClick={handleBack}
+                    >
+                        Back to Previous
+                    </Button>
+                    <Button
+                        component={Link}
+                        href='/'
+                        variant='light'
+                        mt='md'
+                        color='gray'
+                    >
+                        Back to Sign-in
+                    </Button>
+                </div>
             </div>
         </div>
     );


### PR DESCRIPTION
* Adding hotfix for sign-up page styles, which were lost during route refactoring.
* Adding "Back to previous" button to under-construction page, which no longer has sidebar
* Updating tests
  * Updating link tests to new paths
  * Removed unnecessary/fragile tests for under-construction page

## Screenshots

Page is now restored to previous style
<img width="1710" height="945" alt="Screenshot 2025-10-23 at 2 46 15 PM" src="https://github.com/user-attachments/assets/dd865a74-a9c0-401e-ae8a-349f663afbac" />
