### PR TITLE
feat(QDOG 114): password req indicators do not update until field is dirty

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     },
     "prettier": {
         "tabWidth": 4,
-        "endOfLine": "lf",
+        "endOfLine": "crlf",
         "jsxSingleQuote": true
     },
     "lint-staged": {

--- a/src/app/auth/sign-up/layout.module.scss
+++ b/src/app/auth/sign-up/layout.module.scss
@@ -1,4 +1,4 @@
-@import '../../globals.scss';
+@import "../../globals.scss";
 
 .layout {
     display: grid;

--- a/src/app/auth/sign-up/owner/page.tsx
+++ b/src/app/auth/sign-up/owner/page.tsx
@@ -89,7 +89,10 @@ export default function OwnerSignup() {
                         label='Password'
                         required
                     />
-                    <PasswordRequirements password={_password} />
+                    <PasswordRequirements
+                        password={_password}
+                        isDirty={form.isDirty("password")}
+                    />
                 </div>
                 <Group>
                     <Button type='submit'>I'm ready!</Button>

--- a/src/app/auth/sign-up/vet/page.tsx
+++ b/src/app/auth/sign-up/vet/page.tsx
@@ -114,7 +114,10 @@ export default function VetSignup() {
                         label='Password'
                         required
                     />
-                    <PasswordRequirements password={_validatedPassword} />
+                    <PasswordRequirements
+                        password={_validatedPassword}
+                        isDirty={form.isDirty("password")}
+                    />
                 </div>
                 <Group>
                     <Button type='submit'>I'm ready!</Button>

--- a/src/components/signup/passwordRequirements.test.tsx
+++ b/src/components/signup/passwordRequirements.test.tsx
@@ -1,3 +1,5 @@
+// Unit tests created and/or modified with Copilot on GPT-5 mini
+
 import "@testing-library/jest-dom";
 
 import { render, screen } from "~tests/utils/custom-testing-library";
@@ -5,7 +7,7 @@ import PasswordRequirements from "./passwordRequirements";
 
 describe("PasswordRequirements component", () => {
     it("renders all requirements", () => {
-        render(<PasswordRequirements password='Test123!' />);
+        render(<PasswordRequirements password='Test123!' isDirty={false} />);
 
         expect(screen.getByText("At least 8 characters")).toBeInTheDocument();
         expect(screen.getByText("At most 120 characters")).toBeInTheDocument();
@@ -19,19 +21,30 @@ describe("PasswordRequirements component", () => {
         expect(screen.getByText("Includes symbol")).toBeInTheDocument();
     });
 
-    it("shows correct requirements met for given password", () => {
-        render(<PasswordRequirements password='Test123!' />);
+    it("does not show a requirement as met when field is not dirty", () => {
+        render(<PasswordRequirements password='Test123!' isDirty={false} />);
 
-        expect(screen.getByText("At least 8 characters")).toHaveStyle({
-            color: "rgb(0, 128, 128)",
+        // The label element is wrapped by the colored container; check parent for color
+        const atLeastEl = screen.getByText("At least 8 characters");
+        expect(atLeastEl.parentElement).toHaveStyle({
+            color: "rgb(255, 0, 0)",
         });
     });
 
-    it("shows missing requirements for for given password", () => {
-        render(<PasswordRequirements password='weakpassword' />);
-
-        expect(screen.getByText("Includes number")).toHaveStyle({
+    it("shows unmet requirements as red when dirty or not dirty", () => {
+        // when password doesn't include a number, it should be red whether dirty or not
+        render(<PasswordRequirements password='weakpassword' isDirty={true} />);
+        const includesNumber = screen.getByText("Includes number");
+        expect(includesNumber.parentElement).toHaveStyle({
             color: "rgb(255, 0, 0)",
+        });
+    });
+
+    it("shows requirement as met with sufficient password and dirty field", () => {
+        render(<PasswordRequirements password='Test123!' isDirty={true} />);
+        const includesSymbol = screen.getByText("At most 120 characters");
+        expect(includesSymbol.parentElement).toHaveStyle({
+            color: "rgb(0, 128, 128)",
         });
     });
 });

--- a/src/components/signup/passwordRequirements.tsx
+++ b/src/components/signup/passwordRequirements.tsx
@@ -47,8 +47,10 @@ function PasswordRequirement({
 
 export default function PasswordRequirements({
     password,
+    isDirty,
 }: {
     password: string;
+    isDirty: boolean;
 }) {
     return (
         <div>
@@ -56,7 +58,7 @@ export default function PasswordRequirements({
                 <PasswordRequirement
                     key={index}
                     label={requirement.label}
-                    meets={requirement.re.test(password)}
+                    meets={requirement.re.test(password) && isDirty}
                 />
             ))}
         </div>

--- a/src/tests/integration/password-validation/index.test.tsx
+++ b/src/tests/integration/password-validation/index.test.tsx
@@ -1,0 +1,82 @@
+// Integration tests created with help from GPT-5 mini
+import "@testing-library/jest-dom";
+
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "~tests/utils/custom-testing-library";
+
+jest.mock("next/navigation", () => ({
+    useRouter: () => ({ push: jest.fn() }),
+}));
+
+import OwnerSignup from "~app/auth/sign-up/owner/page";
+import VetSignup from "~app/auth/sign-up/vet/page";
+
+describe("Owner Signup", () => {
+    it("shows requirements as red when unmet", async () => {
+        const user = userEvent.setup();
+
+        render(<OwnerSignup />);
+
+        const passwordInput = screen.getByLabelText(/password/i);
+        const atLeast = screen.getByText("At least 8 characters");
+
+        await user.type(passwordInput, "test");
+        expect(atLeast.parentElement).toHaveStyle({ color: "rgb(255, 0, 0)" });
+    });
+
+    it("shows requirements as red when met but not dirty", async () => {
+        render(<OwnerSignup />);
+
+        const passwordInput = screen.getByLabelText(/password/i);
+        const atMost = screen.getByText("At most 120 characters");
+        expect(passwordInput).toHaveAttribute("value", "");
+        expect(atMost.parentElement).toHaveStyle({ color: "rgb(255, 0, 0)" });
+    });
+
+    it("shows requirements as teal when met and dirty", async () => {
+        const user = userEvent.setup();
+
+        render(<OwnerSignup />);
+
+        const passwordInput = screen.getByLabelText(/password/i);
+        const atMost = screen.getByText("At most 120 characters");
+
+        await user.type(passwordInput, "test");
+        expect(atMost.parentElement).toHaveStyle({ color: "rgb(0, 128, 128)" });
+    });
+});
+
+describe("Vet Signup", () => {
+    it("shows requirements as red when unmet", async () => {
+        const user = userEvent.setup();
+
+        render(<VetSignup />);
+
+        const passwordInput = screen.getByLabelText(/password/i);
+        const atLeast = screen.getByText("At least 8 characters");
+
+        await user.type(passwordInput, "test");
+        expect(atLeast.parentElement).toHaveStyle({ color: "rgb(255, 0, 0)" });
+    });
+
+    it("shows requirements as red when met but not dirty", async () => {
+        render(<VetSignup />);
+
+        const passwordInput = screen.getByLabelText(/password/i);
+        const atMost = screen.getByText("At most 120 characters");
+        expect(passwordInput).toHaveAttribute("value", "");
+        expect(atMost.parentElement).toHaveStyle({ color: "rgb(255, 0, 0)" });
+    });
+
+    it("shows requirements as teal when met and dirty", async () => {
+        const user = userEvent.setup();
+
+        render(<VetSignup />);
+
+        const passwordInput = screen.getByLabelText(/password/i);
+        const atMost = screen.getByText("At most 120 characters");
+
+        await user.type(passwordInput, "test");
+        expect(atMost.parentElement).toHaveStyle({ color: "rgb(0, 128, 128)" });
+    });
+});


### PR DESCRIPTION
* Added `isDirty` check to password requirements indicators
* Created integration tests for login pages using indicators

## Screenshots
Password requirements are red until the field is dirty (ie. non-empty)
<img width="581" height="308" alt="qdog-114-unmet-onDirty" src="https://github.com/user-attachments/assets/76fe3386-569a-414a-ad56-bee46bed4dda" />

Password requirements show green if the field has been filled
<img width="538" height="325" alt="qdog-114-met-onDirty" src="https://github.com/user-attachments/assets/8934b8d6-7653-4e51-9b3a-14e13338a087" />
