### PR TITLE
[QDOG 149]Added sign out button to nav bar

### DIFF
--- a/src/components/sidebar.module.scss
+++ b/src/components/sidebar.module.scss
@@ -51,6 +51,8 @@
     transition: transform 0.3s ease;
     transform: translateX(0);
     z-index: 1001;
+    display: flex;
+    flex-direction: column;
 }
 
 /* NavLink font styling */
@@ -78,6 +80,19 @@
 .logo {
     width: 100%;
     height: auto;
+}
+
+.bottom {
+    margin-top: auto;
+    padding-bottom: 50px;
+}
+
+.button {
+    background-color: $color-green-dark;
+
+    &:hover {
+        background-color: $color-green-dark;
+    }
 }
 
 /* Hide logo on mobile */
@@ -115,6 +130,8 @@
         box-shadow: -2px 0 8px rgba(0, 0, 0, 0.1);
         border-left: 1px solid #eee;
         border-right: none;
+        justify-content: space-between;
+        flex: 1;
     }
 
     /* When sidebar is open, slide it in */
@@ -127,3 +144,4 @@
         display: none;
     }
 }
+

--- a/src/components/sidebar.test.tsx
+++ b/src/components/sidebar.test.tsx
@@ -71,8 +71,7 @@ describe("Sidebar Component", () => {
             expect(myPetsLink).toHaveAttribute("href", "/owner/pets/create");
         });
 
-        it("Sign Out should cause alert to appear", () => {
-            //const signoutButton = screen.getByText("My Pets");
+        it("Sign Out Button should navigate back to log in", () => {
             fireEvent.click(screen.getByText("Sign Out"));
             expect(window.confirm).toHaveBeenCalledWith(
                 "Are you sure you want to sign out?",

--- a/src/components/sidebar.test.tsx
+++ b/src/components/sidebar.test.tsx
@@ -17,6 +17,20 @@ import "@testing-library/jest-dom";
 import userEvent from "@testing-library/user-event";
 import { render, screen } from "~tests/utils/custom-testing-library";
 import Sidebar from "./sidebar";
+import { fireEvent } from "~tests/utils/custom-testing-library";
+
+/**
+ * Test suites and mock functions generated with GPT-5 mini and help from:
+ * https://stackoverflow.com/questions/76858797/error-invariant-expected-app-router-to-be-mounted-why-this-happened-when-using
+ */
+const pushMock = jest.fn();
+jest.mock("next/navigation", () => ({
+    useRouter: () => ({
+        push: pushMock,
+    }),
+}));
+
+window.confirm = jest.fn(() => true);
 
 describe("Sidebar Component", () => {
     let user: ReturnType<typeof userEvent.setup>;
@@ -57,6 +71,15 @@ describe("Sidebar Component", () => {
             expect(myPetsLink).toHaveAttribute("href", "/owner/pets/create");
         });
 
+        it("Sign Out should cause alert to appear", () => {
+            //const signoutButton = screen.getByText("My Pets");
+            fireEvent.click(screen.getByText("Sign Out"));
+            expect(window.confirm).toHaveBeenCalledWith(
+                "Are you sure you want to sign out?",
+            );
+            expect(pushMock).toHaveBeenCalledWith("/");
+        });
+
         it("other nav links should link to under-construction page", () => {
             const appointmentsLink = screen
                 .getByText("Appointments")
@@ -85,7 +108,7 @@ describe("Sidebar Component", () => {
         });
 
         it("toggle button should be present", () => {
-            const toggleBtn = screen.getByRole("button");
+            const toggleBtn = screen.getByRole("button", { name: /menu/i });
             expect(toggleBtn).toBeInTheDocument();
             expect(toggleBtn).toHaveClass("toggleBtn");
         });
@@ -96,12 +119,13 @@ describe("Sidebar Component", () => {
             expect(screen.getByText("Appointments")).toBeVisible();
             expect(screen.getByText("Pet Diary")).toBeVisible();
             expect(screen.getByText("Messages")).toBeVisible();
+            expect(screen.getByText("Sign Out")).toBeVisible();
         });
     });
 
     describe("Mobile View - Toggle Functionality", () => {
         it("toggle button should open and close sidebar", async () => {
-            const toggleBtn = screen.getByRole("button");
+            const toggleBtn = screen.getByRole("button", { name: /menu/i });
 
             // sidebar should be closed initially
             let sidebar = screen.getByRole("complementary");
@@ -124,7 +148,7 @@ describe("Sidebar Component", () => {
         });
 
         it("should close sidebar when overlay is clicked", async () => {
-            const toggleBtn = screen.getByRole("button");
+            const toggleBtn = screen.getByRole("button", { name: /menu/i });
 
             // open sidebar first
             await user.click(toggleBtn);
@@ -139,7 +163,7 @@ describe("Sidebar Component", () => {
         });
 
         it("overlay should only appear when sidebar is open", async () => {
-            const toggleBtn = screen.getByRole("button");
+            const toggleBtn = screen.getByRole("button", { name: /menu/i });
 
             // overlay should not exist initially
             expect(
@@ -158,7 +182,7 @@ describe("Sidebar Component", () => {
         });
 
         it("should display navigation links when sidebar is open", async () => {
-            const toggleBtn = screen.getByRole("button");
+            const toggleBtn = screen.getByRole("button", { name: /menu/i });
 
             await user.click(toggleBtn);
 
@@ -183,7 +207,7 @@ describe("Sidebar Component", () => {
         });
 
         it("toggle button should be keyboard accessible", async () => {
-            const toggleBtn = screen.getByRole("button");
+            const toggleBtn = screen.getByRole("button", { name: /menu/i });
             toggleBtn.focus();
             expect(toggleBtn).toHaveFocus();
 
@@ -193,7 +217,7 @@ describe("Sidebar Component", () => {
         });
 
         it("toggle button should have descriptive text", () => {
-            const toggleBtn = screen.getByRole("button");
+            const toggleBtn = screen.getByRole("button", { name: /menu/i });
             expect(toggleBtn).toHaveTextContent("Menu");
         });
     });

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -9,11 +9,12 @@
 
 "use client";
 import Link from "next/link";
-import { NavLink, Stack } from "@mantine/core";
+import { Button, NavLink, Stack } from "@mantine/core";
 import Image from "next/image";
 import { useState } from "react";
 import logo from "~public/logo/tennisLogo.png";
 import styles from "./sidebar.module.scss";
+import { useRouter } from "next/navigation";
 
 /**
  * Sidebar component for navigation:
@@ -25,6 +26,15 @@ export default function Sidebar() {
 
     const toggleSidebar = () => {
         setIsOpen(!isOpen);
+    };
+
+    const router = useRouter();
+
+    const logOut = () => {
+        if (window.confirm("Are you sure you want to sign out?")) {
+            localStorage.clear();
+            router.push("/");
+        }
     };
 
     return (
@@ -88,6 +98,15 @@ export default function Sidebar() {
                         className={styles.navLink}
                     />
                 </Stack>
+                <div className={styles.bottom}>
+                    <Button
+                        variant='filled'
+                        className={styles.button}
+                        onClick={logOut}
+                    >
+                        Sign Out
+                    </Button>
+                </div>
             </aside>
 
             {/* Spacer for desktop - prevents content from hiding behind sidebar */}


### PR DESCRIPTION
Added sign out button to bottom of the sidebar. Clicking on it will cause an alert to confirm and if so it will sign the user out (and delete the local storage that stores their user information). Added a small test to ensure the button works as expected and also slightly modified existing tests as they depended on there only being one button in the sidebar. 

<img width="377" height="668" alt="image" src="https://github.com/user-attachments/assets/c782ef2f-7e06-409e-a71f-178b9944cc58" />

<img width="962" height="478" alt="image" src="https://github.com/user-attachments/assets/e5c55b0d-8891-4484-9766-ddd239e1c0e5" />
