### PR TITLE
chore: Enforce same line ending and remove deprecated husky line

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=crlf

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,4 @@
 #!/usr/bin/env sh
-. "$(dirname "$0")/_/husky.sh"
 
 pnpm lint-staged
 pnpm test:changed

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     },
     "prettier": {
         "tabWidth": 4,
-        "endOfLine": "lf",
+        "endOfLine": "crlf",
         "jsxSingleQuote": true
     },
     "lint-staged": {

--- a/src/data/pets/mock.ts
+++ b/src/data/pets/mock.ts
@@ -1,13 +1,10 @@
 import { AnimalGroup, Pet, SterileStatus } from "src/models/pet";
-import { todayDate } from "~data/constants";
-
-const todayDateString: string = todayDate.toISOString();
 
 export const mockPets: Pet[] = [
     {
         id: "pet1",
         name: "Bella",
-        birthdate: todayDateString,
+        birthdate: new Date("2019-08-01").toISOString(),
         estimatedBirthdate: true,
         sex: "Female",
         animalGroup: AnimalGroup.amphibian,
@@ -19,7 +16,7 @@ export const mockPets: Pet[] = [
     {
         id: "pet2",
         name: "Tweety",
-        birthdate: todayDateString,
+        birthdate: new Date("2024-03-01").toISOString(),
         estimatedBirthdate: true,
         sex: "Female",
         animalGroup: AnimalGroup.bird,

--- a/src/data/pets/mock.ts
+++ b/src/data/pets/mock.ts
@@ -7,7 +7,7 @@ export const mockPets: Pet[] = [
     {
         id: "pet1",
         name: "Bella",
-        birthdate: new Date("2019-08-01").toISOString(),
+        birthdate: todayDateString,
         estimatedBirthdate: true,
         sex: "Female",
         animalGroup: AnimalGroup.amphibian,
@@ -19,7 +19,7 @@ export const mockPets: Pet[] = [
     {
         id: "pet2",
         name: "Tweety",
-        birthdate: new Date("2024-03-01").toISOString(),
+        birthdate: todayDateString,
         estimatedBirthdate: true,
         sex: "Female",
         animalGroup: AnimalGroup.bird,


### PR DESCRIPTION
- Make .gitattributes so no need to run a command to ensure same line ending
- Remove the deprecated husky line and do a test commit to see if pre-commit hook still works
- Remove unused variable (and husky still works)


Note: The new version of Husky treats the files in the .husky directory as standard shell scripts, so no need for the deprecated line. Everyone might need to do pnpm install if you don't have latest husky version