### PR TITLE
chore: Update ci for regression tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,8 +42,17 @@ jobs:
             - name: Lint and format
               run: pnpm lint && pnpm format
 
-            - name: Run tests
-              run: pnpm test
+            - name: "[Regression Tests] - Authentication"
+              run: pnpm test -- src/app/auth
+
+            - name: "[Regression Tests] - Create Diary"
+              run: pnpm test -- src/app/owner/diary/create
+
+            - name: "[Regression Tests] - Create Pet"
+              run: pnpm test -- src/app/owner/pet/create
+
+            - name: "[Regression Tests] - Integration tests"
+              run: pnpm test -- src/tests/integration/password-validation
 
             - name: Build project
               run: pnpm build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
               run: pnpm test -- src/app/owner/diary/create
 
             - name: "[Regression Tests] - Create Pet"
-              run: pnpm test -- src/app/owner/pet/create
+              run: pnpm test -- src/app/owner/pets/create
 
             - name: "[Regression Tests] - Integration tests"
               run: pnpm test -- src/tests/integration/password-validation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
               run: pnpm test -- src/app/owner/pets/create
 
             - name: "[Regression Tests] - Integration tests"
-              run: pnpm test -- src/tests/integration/password-validation
+              run: pnpm test -- src/tests/integration
 
             - name: Build project
               run: pnpm build


### PR DESCRIPTION
- Do selective regression tests for ci when pull requests are made to main and develop 
- Run authentication, create diary and pet, and integration tests as those seem to be high traffic, high risk, or both.

You can see the change worked because in this pr, that's what the github actions ran:
<img width="1058" height="166" alt="image" src="https://github.com/user-attachments/assets/a213fecd-00f4-418c-b547-0f9a06fa9359" />
<img width="672" height="768" alt="image" src="https://github.com/user-attachments/assets/173c875f-6aab-4bc2-aae9-93f03778b376" />
