### PR TITLE
chore: Integrate create diary and pet dashboard with endpoints

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -53,8 +53,6 @@ export default function LoginPage() {
     const router = useRouter();
 
     const handleLogin = async (values: { email: string; password: string }) => {
-        // TODO: check credentials with backend
-
         try {
             if (selectedUser === vet) {
                 const vet = await VetsAPI.vetLogin(values);

--- a/src/app/owner/diary/create/page.test.tsx
+++ b/src/app/owner/diary/create/page.test.tsx
@@ -15,28 +15,8 @@ import {
 } from "~tests/utils/form-helpers/new-diary-form-helper";
 import { notesMaxCharacters, notesMinCharacters } from "~data/pets/constants";
 import { mockPets } from "~data/pets/mock";
-
-// Mock PetsAPI to return mockPets instead of making real API calls
-jest.mock(
-    "src/api/petsAPI",
-    () => ({
-        PetsAPI: {
-            getAllPets: jest.fn(() => Promise.resolve(mockPets)),
-        },
-    }),
-    { virtual: true },
-);
-
-// Mock PetDiaryAPI to prevent actual API calls during form submission
-jest.mock(
-    "src/api/petDiaryAPI",
-    () => ({
-        PetDiaryAPI: {
-            createDiary: jest.fn(() => Promise.resolve({ success: true })),
-        },
-    }),
-    { virtual: true },
-);
+import { PetDiaryAPI } from "~api/petDiaryAPI";
+import { PetsAPI } from "~api/petsAPI";
 
 // Mock router
 const pushMock = jest.fn();
@@ -78,6 +58,11 @@ describe("New Diary Entry page", () => {
     let saveButton: HTMLElement;
     let user: ReturnType<typeof userEvent.setup>;
 
+    beforeEach(() => {
+        jest.clearAllMocks();
+        PetDiaryAPI.createDiary = jest.fn().mockResolvedValue({});
+    });
+
     describe("Regular functionality", () => {
         beforeEach(async () => {
             jest.clearAllMocks();
@@ -92,6 +77,8 @@ describe("New Diary Entry page", () => {
             );
 
             user = userEvent.setup();
+
+            PetsAPI.getAllPets = jest.fn().mockResolvedValue(mockPets);
             render(<NewDiary />);
 
             ({
@@ -311,11 +298,8 @@ describe("New Diary Entry page", () => {
         });
 
         describe("Cancel button", () => {
-            it("navigates to diary dashboard when clicked", async () => {
-                const cancelBtn = screen.getByRole("button", {
-                    name: /cancel/i,
-                });
-                await user.click(cancelBtn);
+            it("navigates to dashboard when clicked", async () => {
+                await user.click(cancelButton);
 
                 async () =>
                     expect(pushMock).toHaveBeenCalledWith(
@@ -386,6 +370,9 @@ describe("New Diary Entry page", () => {
             mockGet.mockReturnValue(null);
 
             // Don't set up localStorage - simulating no logged-in user
+            // Mock will return empty array for pets since no owner ID
+            PetsAPI.getAllPets = jest.fn().mockResolvedValue([]);
+
             user = userEvent.setup();
             render(<NewDiary />);
 
@@ -420,6 +407,12 @@ describe("New Diary Entry page", () => {
                 /you cannot make a diary entry for your pet without being logged in./i,
             );
             expect(errorMsg).toBeInTheDocument();
+            // Get only the save button - no need to fill form for this test
+            ({ saveButton } = await getNewDiaryElements());
+        });
+
+        it("shows user can't submit when user is not logged in", async () => {
+            await user.click(saveButton);
             expect(pushMock).not.toHaveBeenCalled();
         });
     });

--- a/src/app/owner/diary/create/page.test.tsx
+++ b/src/app/owner/diary/create/page.test.tsx
@@ -21,7 +21,7 @@ import { owner } from "~data/owner/mock";
 
 // Mock router
 const pushMock = jest.fn();
-const mockGet = jest.fn(() => null);
+const mockGet = jest.fn((key: string) => null);
 
 jest.mock("next/navigation", () => ({
     useRouter: () => ({
@@ -312,7 +312,7 @@ describe("New Diary Entry page", () => {
             jest.clearAllMocks();
 
             // Mock mockGet to return "Diet" for noteType query param
-            mockGet.mockImplementation((key) => {
+            mockGet.mockImplementation((key: string) => {
                 if (key === "noteType") return "Diet";
                 return null;
             });
@@ -373,40 +373,6 @@ describe("New Diary Entry page", () => {
 
             user = userEvent.setup();
             render(<NewDiary />);
-
-            ({
-                pet,
-                noteType,
-                notes,
-                resetMediaButton,
-                uploadMediaButton,
-                cancelButton,
-                saveButton,
-            } = await getNewDiaryElements());
-
-            // Fill form with valid data
-            fireEvent.change(notes, {
-                target: { value: "Valid diary notes here" },
-            });
-
-            await pickSelectDefaults({
-                user,
-                petEl: pet,
-                noteTypeEl: noteType,
-                petText: "Bella",
-                noteTypeText: "General",
-            });
-        });
-
-        it("shows error when user is not logged in", async () => {
-            await user.click(saveButton);
-
-            const errorMsg = await screen.findByText(
-                /you cannot make a diary entry for your pet without being logged in./i,
-            );
-            expect(errorMsg).toBeInTheDocument();
-            // Get only the save button - no need to fill form for this test
-            ({ saveButton } = await getNewDiaryElements());
         });
 
         it("shows user can't submit when user is not logged in", async () => {

--- a/src/app/owner/diary/create/page.test.tsx
+++ b/src/app/owner/diary/create/page.test.tsx
@@ -17,6 +17,7 @@ import { notesMaxCharacters, notesMinCharacters } from "~data/pets/constants";
 import { mockPets } from "~data/pets/mock";
 import { PetDiaryAPI } from "~api/petDiaryAPI";
 import { PetsAPI } from "~api/petsAPI";
+import { owner } from "~data/owner/mock";
 
 // Mock router
 const pushMock = jest.fn();
@@ -71,10 +72,7 @@ describe("New Diary Entry page", () => {
             mockGet.mockReturnValue(null);
 
             // Set up mock user in localStorage
-            localStorage.setItem(
-                "currentUser",
-                JSON.stringify({ id: 1, firstName: "Test", lastName: "User" }),
-            );
+            localStorage.setItem("currentUser", JSON.stringify(owner));
 
             user = userEvent.setup();
 

--- a/src/app/owner/diary/create/page.tsx
+++ b/src/app/owner/diary/create/page.tsx
@@ -38,6 +38,9 @@ function NewDiary() {
 
     const [pets, setPets] = useState<Pet[]>([]);
 
+    // TODO: Make a util function for fetching pets and return the pets? to reduce duplicate code
+    // localStorage code above might benefit from this too but we are switching to firestore so not needed
+
     // Load pets when owner is available
     useEffect(() => {
         const fetchPets = async () => {
@@ -47,7 +50,7 @@ function NewDiary() {
                     setPets(fetchedPets);
                 } catch (error) {
                     setError(
-                        "You cannot make a diary entry for your pet without having any pet.",
+                        "We can't retrieve all your pets. Please try again later.",
                     );
                 }
             }

--- a/src/app/owner/diary/create/page.tsx
+++ b/src/app/owner/diary/create/page.tsx
@@ -14,6 +14,7 @@ import { Pet } from "src/models/pet";
 import { Owner } from "src/models/owner";
 import { PetsAPI } from "~api/petsAPI";
 import { PetDiaryAPI } from "~api/petDiaryAPI";
+import { todayDate } from "~data/constants";
 
 /**
  * Some sample code came from Mantine use-file-dialog
@@ -66,14 +67,14 @@ function NewDiary() {
             pet: null,
             contentType: "",
             contentBody: "",
-            media: null,
+            files: null,
         },
 
         validate: {
             pet: isNotEmpty("This pet field can't be empty."),
             contentType: isNotEmpty("This note type field can't be empty."),
             contentBody: validateDiaryContentBody,
-            media: validateOptionalImage,
+            files: validateOptionalImage,
         },
     });
 
@@ -99,15 +100,20 @@ function NewDiary() {
         accept: "image/*",
     });
 
-    const pickedMedia = Array.from(fileDialog.files || []);
-    const pickedMediaList = pickedMedia.map((file) => (
+    const pickedFiles = Array.from(fileDialog.files || []);
+    const pickedFilesList = pickedFiles.map((file) => (
         <List.Item key={file.name}>{file.name}</List.Item>
     ));
 
-    // clears file dialog and resets media contents
-    const resetMedia = () => {
+    // clears file dialog and resets files contents
+    const resetFiles = () => {
         fileDialog.reset();
-        form.setFieldValue("media", null);
+        form.setFieldValue("files", null);
+    };
+
+    const findPetIdByName = (petName: string): string | null => {
+        const pet = pets.find((p) => p.name === petName);
+        return pet?.id || null;
     };
 
     const handleSubmit = async (values: typeof form.values) => {
@@ -115,19 +121,23 @@ function NewDiary() {
             setError("");
 
             if (owner?.id != null) {
+                const petId = findPetIdByName(values.pet);
+
+                if (!petId) {
+                    setError("Unable to find the selected pet.");
+                    return;
+                }
+
                 const diaryEntryJSON = {
-                    ...values,
-                    media: pickedMedia,
+                    contentBody: values.contentBody,
+                    contentType: values.contentType,
+                    createTimestamp: todayDate,
+                    files: [],
                 };
 
                 const diaryEntry = new PetDiary(diaryEntryJSON);
 
-                await PetDiaryAPI.createDiary(
-                    owner.id,
-                    values.pet.id,
-                    diaryEntry,
-                );
-
+                await PetDiaryAPI.createDiary(petId, diaryEntry);
                 router.push("/owner/dashboard"); // TODO: change to diary once created
             } else {
                 setError(
@@ -188,7 +198,7 @@ function NewDiary() {
                                 entry.
                             </p>
                             <Group>
-                                <Button variant='default' onClick={resetMedia}>
+                                <Button variant='default' onClick={resetFiles}>
                                     Reset
                                 </Button>
                                 <Button
@@ -200,9 +210,9 @@ function NewDiary() {
                                     Upload
                                 </Button>
                             </Group>
-                            {pickedMediaList.length > 0 && (
+                            {pickedFilesList.length > 0 && (
                                 <List mt='sm' size='sm'>
-                                    {pickedMediaList}
+                                    {pickedFilesList}
                                 </List>
                             )}
                         </div>

--- a/src/app/owner/diary/create/page.tsx
+++ b/src/app/owner/diary/create/page.tsx
@@ -11,8 +11,9 @@ import { Button, Group, List, Select, Textarea } from "@mantine/core";
 import { noteTypeOptions } from "~data/diary/constants";
 import { useFileDialog } from "@mantine/hooks";
 import { Pet } from "src/models/pet";
-import { mockPets } from "~data/pets/mock";
 import { Owner } from "src/models/owner";
+import { PetsAPI } from "~api/petsAPI";
+import { PetDiaryAPI } from "~api/petDiaryAPI";
 
 /**
  * Some sample code came from Mantine use-file-dialog
@@ -34,17 +35,25 @@ function NewDiary() {
         }
     }, []);
 
-    let pets: Pet[];
-    try {
-        pets = mockPets;
+    const [pets, setPets] = useState<Pet[]>([]);
 
-        // TODO: use this instead after the getAllPets is implemented in backend
-        // pets = await PetsAPI.getAllPets(user.id);
-    } catch (error) {
-        setError(
-            "You cannot make a diary entry for your pet without having any pet.",
-        );
-    }
+    // Load pets when owner is available
+    useEffect(() => {
+        const fetchPets = async () => {
+            if (owner?.id) {
+                try {
+                    const fetchedPets = await PetsAPI.getAllPets(owner.id);
+                    setPets(fetchedPets);
+                } catch (error) {
+                    setError(
+                        "You cannot make a diary entry for your pet without having any pet.",
+                    );
+                }
+            }
+        };
+
+        fetchPets();
+    }, [owner]); // Run when owner changes
 
     const petOptions: string[] = [];
     for (let pet of pets) {
@@ -113,8 +122,11 @@ function NewDiary() {
 
                 const diaryEntry = new PetDiary(diaryEntryJSON);
 
-                // TODO: uncomment after the getAllPets is implemented in backend
-                // await PetDiaryAPI.createDiary(owner.id, values.pet.id, diaryEntry);
+                await PetDiaryAPI.createDiary(
+                    owner.id,
+                    values.pet.id,
+                    diaryEntry,
+                );
 
                 router.push("/owner/dashboard"); // TODO: change to diary once created
             } else {
@@ -124,7 +136,9 @@ function NewDiary() {
             }
         } catch (error) {
             console.error("Error in handleSubmit: ", error);
-            setError("You cannot make a diary entry."); // TODO: Add a more specific error depending on backend's implementation
+            setError(
+                "Something went wrong with our server when creating diary. Please try again later.",
+            );
         }
     };
 

--- a/src/app/owner/diary/create/page.tsx
+++ b/src/app/owner/diary/create/page.tsx
@@ -141,7 +141,7 @@ function NewDiary() {
                 const diaryEntry = new PetDiary(diaryEntryJSON);
 
                 await PetDiaryAPI.createDiary(petId, diaryEntry);
-                router.push("/owner/dashboard"); // TODO: change to diary once created
+                router.push("/owner/diary/dashboard");
             } else {
                 setError(
                     "You cannot make a diary entry for your pet without being logged in.",

--- a/src/app/owner/diary/dashboard/page.test.tsx
+++ b/src/app/owner/diary/dashboard/page.test.tsx
@@ -37,9 +37,7 @@ describe("Pet Diary Dashboard", () => {
         });
 
         it("renders the placeholder for diary entries", () => {
-            expect(
-                screen.getByText("Diary entries will appear here"),
-            ).toBeInTheDocument();
+            expect(screen.getByText("No diary entry yet")).toBeInTheDocument();
         });
 
         it("renders the Quick Add sidebar", () => {

--- a/src/app/owner/diary/dashboard/page.tsx
+++ b/src/app/owner/diary/dashboard/page.tsx
@@ -1,10 +1,17 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { IconPlus, IconArrowsSort } from "@tabler/icons-react";
 import { noteTypeOptions } from "src/data/diary/constants";
 import styles from "./page.module.scss";
+import globalStyles from "~app/layout.module.scss";
+import { Pet } from "src/models/pet";
+import { Owner } from "src/models/owner";
+import { PetsAPI } from "~api/petsAPI";
+import { PetDiaryAPI } from "~api/petDiaryAPI";
+import { PetDiary } from "src/models/pet-diary";
+import DiaryEntry from "~components/diaryEntry/diaryEntry";
 
 /**
  * CREDITS
@@ -17,6 +24,67 @@ import styles from "./page.module.scss";
 
 export default function PetDiaryDashboard() {
     const router = useRouter();
+
+    const [error, setError] = useState("");
+    const [owner, setOwner] = useState<Owner>(null);
+
+    useEffect(() => {
+        let storedUser = localStorage.getItem("currentUser");
+        if (storedUser) {
+            const storedOwner = new Owner(JSON.parse(storedUser));
+
+            setOwner(storedOwner);
+        }
+    }, []);
+
+    const [pets, setPets] = useState<Pet[]>([]);
+
+    // TODO: Make a util function for fetching pets and return the pets? to reduce duplicate code
+    // localStorage code above might benefit from this too but we are switching to firestore so not needed
+
+    useEffect(() => {
+        const fetchPets = async () => {
+            if (owner?.id) {
+                try {
+                    const fetchedPets = await PetsAPI.getAllPets(owner.id);
+                    setPets(fetchedPets);
+                } catch (error) {
+                    setError(
+                        "We can't retrieve all your pets. Please try again later.",
+                    );
+                }
+            }
+        };
+
+        fetchPets();
+    }, [owner]);
+
+    // TODO: Make a util function for fetching diaries and return the diaries? to reduce duplicate code
+    const [diaries, setDiaries] = useState<PetDiary[]>([]);
+
+    useEffect(() => {
+        const fetchDiaries = async () => {
+            if (owner?.id && pets.length > 0) {
+                try {
+                    const fetchedDiaries: PetDiary[] = [];
+                    for (const pet of pets) {
+                        const petDiaries = await PetDiaryAPI.getDiaryEntries(
+                            pet.id,
+                        );
+                        fetchedDiaries.push(...petDiaries);
+                    }
+
+                    setDiaries(fetchedDiaries);
+                } catch (error) {
+                    setError(
+                        "We can't retrieve all your diary entries. Please try again later.",
+                    );
+                }
+            }
+        };
+
+        fetchDiaries();
+    }, [owner, pets]);
 
     const [activeFilter, setActiveFilter] = useState("All");
     const [sortBy, setSortBy] = useState("Newest first");
@@ -88,9 +156,17 @@ export default function PetDiaryDashboard() {
 
                     {/* Diary Entries Placeholder */}
                     <div className={styles.entriesContainer}>
-                        <div className={styles.placeholder}>
-                            Diary entries will appear here
-                        </div>
+                        {diaries && diaries.length <= 0 && (
+                            <p>No diary entry yet</p>
+                        )}
+
+                        {diaries &&
+                            diaries.length > 0 &&
+                            diaries.map((diary) => (
+                                <DiaryEntry key={diary.id} entry={diary} />
+                            ))}
+
+                        <p className={globalStyles.error_message}>{error}</p>
                     </div>
 
                     <aside className={styles.diarySidebar}>

--- a/src/app/owner/pets/create/page.tsx
+++ b/src/app/owner/pets/create/page.tsx
@@ -145,7 +145,7 @@ export default function NewPet() {
                 } else {
                     petJSON.petImage = null;
                 }
-                router.push("/owner/dashboard");
+                router.push("/owner/pets/dashboard");
             } else {
                 setError("You cannot make a pet without being logged in.");
             }
@@ -155,7 +155,7 @@ export default function NewPet() {
     };
 
     const handleCancel = () => {
-        router.push("/owner/dashboard");
+        router.push("/owner/pets/dashboard");
     };
 
     return (

--- a/src/app/owner/pets/dashboard/page.module.scss
+++ b/src/app/owner/pets/dashboard/page.module.scss
@@ -4,9 +4,9 @@
 @import "../../../globals.scss";
 
 .page {
-    background-color: $color-white;
-    min-height: 100vh;
-    padding: 40px;
+  background-color: $color-white;
+  min-height: 100vh;
+  padding: 5% 8%;
 }
 
 // HEADER SECTION

--- a/src/app/owner/pets/dashboard/page.test.tsx
+++ b/src/app/owner/pets/dashboard/page.test.tsx
@@ -2,6 +2,9 @@ import "@testing-library/jest-dom";
 import { render, screen } from "~tests/utils/custom-testing-library";
 import userEvent from "@testing-library/user-event";
 import PetDashboard from "./page";
+import { mockPets } from "~data/pets/mock";
+import { PetsAPI } from "~api/petsAPI";
+import { owner } from "~data/owner/mock";
 
 /**
  * CREDITS
@@ -78,6 +81,11 @@ describe("Pet Dashboard page", () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+
+        // Set up mock user in localStorage so pets will load
+        localStorage.setItem("currentUser", JSON.stringify(owner));
+
+        PetsAPI.getAllPets = jest.fn().mockResolvedValue(mockPets);
         user = userEvent.setup();
     });
 
@@ -115,8 +123,9 @@ describe("Pet Dashboard page", () => {
     });
 
     describe("Pet cards display", () => {
-        beforeEach(() => {
+        beforeEach(async () => {
             render(<PetDashboard />);
+            await screen.findByText("Bella");
         });
 
         it("renders all pet cards from mock data", () => {
@@ -132,8 +141,9 @@ describe("Pet Dashboard page", () => {
     });
 
     describe("Pet information display", () => {
-        beforeEach(() => {
+        beforeEach(async () => {
             render(<PetDashboard />);
+            await screen.findByText("Bella");
         });
 
         it("displays pet information correctly", () => {
@@ -153,8 +163,9 @@ describe("Pet Dashboard page", () => {
     });
 
     describe("Pet card interactions", () => {
-        beforeEach(() => {
+        beforeEach(async () => {
             render(<PetDashboard />);
+            await screen.findByText("Bella");
         });
 
         it("renders EDIT badge for each pet card", () => {
@@ -172,9 +183,7 @@ describe("Pet Dashboard page", () => {
         it("navigates to under construction when edit button is clicked", async () => {
             const editBadges = screen.getAllByRole("button", { name: /edit/i });
             await user.click(editBadges[0]);
-
-            async () =>
-                expect(pushMock).toHaveBeenCalledWith("/under-construction");
+            expect(pushMock).toHaveBeenCalledWith("/under-construction");
         });
 
         it("renders View Details button for each pet card", () => {
@@ -204,8 +213,9 @@ describe("Pet Dashboard page", () => {
     });
 
     describe("Info row labels", () => {
-        beforeEach(() => {
+        beforeEach(async () => {
             render(<PetDashboard />);
+            await screen.findByText("Bella");
         });
 
         it("displays Age label for each pet", () => {

--- a/src/app/owner/pets/dashboard/page.test.tsx
+++ b/src/app/owner/pets/dashboard/page.test.tsx
@@ -169,6 +169,14 @@ describe("Pet Dashboard page", () => {
             expect(editBadges[0]).toBeInTheDocument();
         });
 
+        it("navigates to under construction when edit button is clicked", async () => {
+            const editBadges = screen.getAllByRole("button", { name: /edit/i });
+            await user.click(editBadges[0]);
+
+            async () =>
+                expect(pushMock).toHaveBeenCalledWith("/under-construction");
+        });
+
         it("renders View Details button for each pet card", () => {
             const viewDetailsButtons = screen.getAllByRole("button", {
                 name: /view details/i,
@@ -183,6 +191,15 @@ describe("Pet Dashboard page", () => {
             await user.click(viewDetailsButtons[0]);
             // Button should remain in document after click
             expect(viewDetailsButtons[0]).toBeInTheDocument();
+        });
+
+        it("navigates to pet details page when view details button is clicked", async () => {
+            const viewDetailsButtons = screen.getAllByRole("button", {
+                name: /view details/i,
+            });
+            await user.click(viewDetailsButtons[0]);
+
+            async () => expect(pushMock).toHaveBeenCalledWith("/owner/pets/1");
         });
     });
 

--- a/src/app/owner/pets/dashboard/page.tsx
+++ b/src/app/owner/pets/dashboard/page.tsx
@@ -1,13 +1,17 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { mockPets } from "src/data/pets/mock";
 import calculateAge from "src/util/ageCalculator";
 import styles from "./page.module.scss";
+import globalStyles from "~app/layout.module.scss";
 import placeholderImage from "~public/placeholder.jpg";
 import { Image } from "@mantine/core";
 import { IconPlus } from "@tabler/icons-react";
 import { getAnimalGroupDisplayLabel } from "src/util/strings/format-pet";
+import { PetsAPI } from "~api/petsAPI";
+import { Owner } from "src/models/owner";
+import { Pet } from "src/models/pet";
 
 /**
  * CREDITS
@@ -31,6 +35,41 @@ const InfoRow = ({ label, value }: { label: string; value: string }) => {
 export default function PetDashboard() {
     const router = useRouter();
 
+    const [error, setError] = useState("");
+    const [owner, setOwner] = useState<Owner>(null);
+
+    useEffect(() => {
+        let storedUser = localStorage.getItem("currentUser");
+        if (storedUser) {
+            const storedOwner = new Owner(JSON.parse(storedUser));
+
+            setOwner(storedOwner);
+        }
+    }, []);
+
+    const [pets, setPets] = useState<Pet[]>([]);
+
+    // TODO: Make a util function for fetching pets and return the pets? to reduce duplicate code
+    // localStorage code above might benefit from this too but we are switching to firestore so not needed
+
+    // Load pets when owner is available
+    useEffect(() => {
+        const fetchPets = async () => {
+            if (owner?.id) {
+                try {
+                    const fetchedPets = await PetsAPI.getAllPets(owner.id);
+                    setPets(fetchedPets);
+                } catch (error) {
+                    setError(
+                        "You cannot make a diary entry for your pet without having any pet.",
+                    );
+                }
+            }
+        };
+
+        fetchPets();
+    }, [owner]); // Run when owner changes
+
     return (
         <div className={styles.page}>
             <main>
@@ -46,65 +85,79 @@ export default function PetDashboard() {
                 </div>
 
                 {/* PET CARD GRID */}
-                <div className={styles.pet_grid}>
-                    {mockPets.map((pet) => (
-                        <div key={pet.id} className={styles.pet_card}>
-                            <div className={styles.pet_image}>
-                                <Image
-                                    src={placeholderImage.src}
-                                    alt={`${pet.name} photo`}
-                                    className={styles.image_icon}
-                                />
-                            </div>
+                {pets && pets.length <= 0 && (
+                    <p>No pets found. Add yours now!</p>
+                )}
+                {pets && pets.length > 0 && (
+                    <div className={styles.pet_grid}>
+                        {pets.map((pet) => (
+                            <div key={pet.id} className={styles.pet_card}>
+                                <div className={styles.pet_image}>
+                                    <Image
+                                        src={
+                                            placeholderImage.src
+                                        }
+                                        alt={`${pet.name} photo`}
+                                        className={styles.image_icon}
+                                    />
+                                </div>
 
-                            <div className={styles.pet_content}>
-                                <div className={styles.pet_header}>
-                                    <h3 className={styles.pet_name}>
-                                        {pet.name}
-                                    </h3>
+                                <div className={styles.pet_content}>
+                                    <div className={styles.pet_header}>
+                                        <h3 className={styles.pet_name}>
+                                            {pet.name}
+                                        </h3>
 
-                                    {/* TODO: Link to edit page when implemented */}
+                                        {/* TODO: Link to edit page when implemented */}
+                                        <button
+                                            className={styles.edit_badge}
+                                            onClick={() =>
+                                                router.push(
+                                                    "/under-construction",
+                                                )
+                                            }
+                                            type='button'
+                                        >
+                                            Edit
+                                        </button>
+                                    </div>
+
+                                    <InfoRow
+                                        label='Age'
+                                        value={calculateAge(pet.birthdate)}
+                                    />
+                                    <InfoRow label='Sex' value={pet.sex} />
+                                    <InfoRow
+                                        label='Animal group'
+                                        value={getAnimalGroupDisplayLabel(
+                                            pet.animalGroup,
+                                        )}
+                                    />
+                                    <InfoRow
+                                        label='Species'
+                                        value={pet.species}
+                                    />
+                                    <InfoRow
+                                        label='Breed/Variety'
+                                        value={pet.breed}
+                                    />
+
                                     <button
-                                        className={styles.edit_badge}
+                                        className={styles.view_details_button}
                                         onClick={() =>
-                                            router.push("/under-construction")
+                                            router.push(`/owner/pets/${pet.id}`)
                                         }
                                         type='button'
                                     >
-                                        Edit
+                                        View Details
                                     </button>
                                 </div>
-
-                                <InfoRow
-                                    label='Age'
-                                    value={calculateAge(pet.birthdate)}
-                                />
-                                <InfoRow label='Sex' value={pet.sex} />
-                                <InfoRow
-                                    label='Animal group'
-                                    value={getAnimalGroupDisplayLabel(
-                                        pet.animalGroup,
-                                    )}
-                                />
-                                <InfoRow label='Species' value={pet.species} />
-                                <InfoRow
-                                    label='Breed/Variety'
-                                    value={pet.breed}
-                                />
-
-                                <button
-                                    className={styles.view_details_button}
-                                    onClick={() =>
-                                        router.push(`/owner/pets/${pet.id}`)
-                                    }
-                                    type='button'
-                                >
-                                    View Details
-                                </button>
                             </div>
-                        </div>
-                    ))}
-                </div>
+                        ))}
+                    </div>
+                )}
+
+                <p className={globalStyles.error_message}>{error}</p>
             </main>
         </div>
     );

--- a/src/app/owner/pets/dashboard/page.tsx
+++ b/src/app/owner/pets/dashboard/page.tsx
@@ -52,7 +52,6 @@ export default function PetDashboard() {
     // TODO: Make a util function for fetching pets and return the pets? to reduce duplicate code
     // localStorage code above might benefit from this too but we are switching to firestore so not needed
 
-    // Load pets when owner is available
     useEffect(() => {
         const fetchPets = async () => {
             if (owner?.id) {
@@ -61,14 +60,14 @@ export default function PetDashboard() {
                     setPets(fetchedPets);
                 } catch (error) {
                     setError(
-                        "You cannot make a diary entry for your pet without having any pet.",
+                        "We can't retrieve all your pets. Please try again later.",
                     );
                 }
             }
         };
 
         fetchPets();
-    }, [owner]); // Run when owner changes
+    }, [owner]);
 
     return (
         <div className={styles.page}>

--- a/src/app/owner/pets/dashboard/page.tsx
+++ b/src/app/owner/pets/dashboard/page.tsx
@@ -92,11 +92,10 @@ export default function PetDashboard() {
                                     value={pet.breed}
                                 />
 
-                                {/* TODO: Link to pet details page when implemented */}
                                 <button
                                     className={styles.view_details_button}
                                     onClick={() =>
-                                        router.push("/under-construction")
+                                        router.push(`/owner/pets/${pet.id}`)
                                     }
                                     type='button'
                                 >

--- a/src/data/diary/mock.ts
+++ b/src/data/diary/mock.ts
@@ -7,9 +7,9 @@ export const MOCK_DIARY_ENTRY: PetDiary = {
     id: MOCK_DIARY_ID,
     contentType: ContentType.general,
     contentBody: "This is a mock diary entry.",
-    createTimestamp: new Date("2025-01-01"),
+    createTimestamp: new Date("2025-01-01").toISOString(),
     pet: mockPets[0],
-    media: [],
+    files: [],
 };
 
 export const MOCK_DIARY_ENTRIES: PetDiary[] = [MOCK_DIARY_ENTRY];

--- a/src/data/owner/mock.ts
+++ b/src/data/owner/mock.ts
@@ -1,0 +1,1 @@
+export const owner = { id: 1, name: "Test" }; // just for local storage, no need to match the actual owner

--- a/src/models/pet-diary.ts
+++ b/src/models/pet-diary.ts
@@ -13,8 +13,8 @@ export class PetDiary {
     public readonly pet: Pet;
     public readonly contentType: ContentType;
     public readonly contentBody: string;
-    public readonly createTimestamp: Date;
-    public readonly media: File[];
+    public readonly createTimestamp: string;
+    public readonly files: string[];
 
     constructor(JSON) {
         Object.assign(this, JSON);


### PR DESCRIPTION
- Change petDiaryAPI to use string id
- Address todo comments and remove them
- Connect create and get diary, and get pets endpoints to front end
- Modify test files to match expected values now that real endpoints are connected. All tests pass now.
- Add some tests for route in pets dashboard

Note: having issues running emulator in backend, so can't actually test it. WIll try again tomorrow asap.