### PR TITLE
Feature (QDOG 172): Update Sidebar For Vet

### DIFF
--- a/src/app/owner/dashboard/page.module.scss
+++ b/src/app/owner/dashboard/page.module.scss
@@ -10,18 +10,19 @@
     padding: 40px; /* top + general spacing */
     background-color: #f9f9f9;
     text-align: left;
+    padding: 5% 10%;
 
     h1 {
         font-size: 2.5rem;
         font-weight: 700;
         margin-bottom: 10px;
-        color: #333;
+        color: $color-black;
     }
 
     p {
         font-size: $font-medium;
         font-weight: 400;
-        color: #333;
+        color: $color-black;
         margin-top: 0;
     }
 }

--- a/src/app/owner/layout.tsx
+++ b/src/app/owner/layout.tsx
@@ -10,7 +10,7 @@ export default function OwnerLayout({
 }) {
     return (
         <div className={styles.layout}>
-            <Sidebar navLinks={ownerNavLinks}/>
+            <Sidebar navLinks={ownerNavLinks} variant="owner" />
             <main className={styles.content}>{children}</main>
         </div>
     );

--- a/src/app/owner/layout.tsx
+++ b/src/app/owner/layout.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Sidebar from "~components/sidebar/sidebar";
+import { ownerNavLinks } from "~components/sidebar/sidebar-config";
 import styles from "../layout.module.scss";
 
 export default function OwnerLayout({
@@ -9,7 +10,7 @@ export default function OwnerLayout({
 }) {
     return (
         <div className={styles.layout}>
-            <Sidebar />
+            <Sidebar navLinks={ownerNavLinks}/>
             <main className={styles.content}>{children}</main>
         </div>
     );

--- a/src/app/owner/pets/dashboard/page.module.scss
+++ b/src/app/owner/pets/dashboard/page.module.scss
@@ -18,7 +18,6 @@
     font-size: $font-xlarge;
     font-weight: 700;
     margin: 0 0 20px 0;
-    color: $color-black;
 }
 
 .add_button {

--- a/src/app/vet/dashboard/page.module.scss
+++ b/src/app/vet/dashboard/page.module.scss
@@ -1,3 +1,32 @@
+@import "../../globals.scss";
+
 .page {
     padding: 5% 10%;
+
+    h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin-bottom: 10px;
+            color: $color-black;
+        }
+
+        p {
+            font-size: $font-medium;
+            font-weight: 400;
+            color: $color-black;
+            margin-top: 0;
+        }
+}
+
+/* responsive font sizes */
+@media (max-width: $size-mobile) {
+    .page h1 {
+        font-size: 1.8rem;
+    }
+}
+
+@media (min-width: $size-tablet) {
+    .page h1 {
+        font-size: 2.5rem;
+    }
 }

--- a/src/app/vet/dashboard/page.module.scss
+++ b/src/app/vet/dashboard/page.module.scss
@@ -8,14 +8,14 @@
             font-weight: 700;
             margin-bottom: 10px;
             color: $color-black;
-        }
+    }
 
-        p {
-            font-size: $font-medium;
-            font-weight: 400;
-            color: $color-black;
-            margin-top: 0;
-        }
+    p {
+        font-size: $font-medium;
+        font-weight: 400;
+        color: $color-black;
+        margin-top: 0;
+    }
 }
 
 /* responsive font sizes */

--- a/src/app/vet/layout.tsx
+++ b/src/app/vet/layout.tsx
@@ -6,7 +6,7 @@ import styles from "../layout.module.scss";
 export default function VetLayout({ children }: { children: React.ReactNode }) {
     return (
         <div className={styles.layout}>
-            <Sidebar navLinks={vetNavLinks} />
+            <Sidebar navLinks={vetNavLinks} variant="vet" />
             <main className={styles.content}>{children}</main>
         </div>
     );

--- a/src/app/vet/layout.tsx
+++ b/src/app/vet/layout.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import Sidebar from "~components/sidebar/sidebar";
+import { vetNavLinks } from "~components/sidebar/sidebar-config";
 import styles from "../layout.module.scss";
 
 export default function VetLayout({ children }: { children: React.ReactNode }) {
     return (
         <div className={styles.layout}>
-            <Sidebar />
+            <Sidebar navLinks={vetNavLinks} />
             <main className={styles.content}>{children}</main>
         </div>
     );

--- a/src/components/sidebar/sidebar-config.ts
+++ b/src/components/sidebar/sidebar-config.ts
@@ -1,0 +1,60 @@
+/**
+ * Sidebar Navigation Configuration
+ *
+ * Developed with assistance from Claude AI (Anthropic) for:
+ * - Organizing navigation links by user type
+ * - Following DRY principles with reusable configurations
+ */
+
+export interface NavLinkItem {
+    label: string;
+    href: string;
+}
+
+/**
+ * Navigation links for pet owners
+ */
+export const ownerNavLinks: NavLinkItem[] = [
+    {
+        label: "Dashboard",
+        href: "/owner/dashboard",
+    },
+    {
+        label: "My Pets",
+        href: "/owner/pets/dashboard",
+    },
+    {
+        label: "Appointments",
+        href: "/under-construction",
+    },
+    {
+        label: "Pet Diary",
+        href: "/owner/diary/dashboard",
+    },
+    {
+        label: "Messages",
+        href: "/under-construction",
+    },
+];
+
+/**
+ * Navigation links for veterinarians
+ */
+export const vetNavLinks: NavLinkItem[] = [
+    {
+        label: "Dashboard",
+        href: "/vet/dashboard",
+    },
+    {
+        label: "Appointments",
+        href: "/under-construction",
+    },
+    {
+        label: "Patients",
+        href: "/under-construction",
+    },
+    {
+        label: "Messages",
+        href: "/under-construction",
+    },
+];

--- a/src/components/sidebar/sidebar.module.scss
+++ b/src/components/sidebar/sidebar.module.scss
@@ -112,10 +112,20 @@
 }
 
 .button {
-    background-color: $color-green-dark;
-
-    &:hover {
+    .owner & {
         background-color: $color-green-dark;
+
+        &:hover {
+                background-color: rgba($color-green-dark, 0.75);
+            }
+    }
+
+    .vet & {
+        background-color: $color-orange-dark;
+
+        &:hover {
+            background-color: rgba($color-orange-dark, 0.75);
+        }
     }
 }
 

--- a/src/components/sidebar/sidebar.module.scss
+++ b/src/components/sidebar/sidebar.module.scss
@@ -46,13 +46,20 @@
     position: fixed;
     left: 0;
     top: 0;
-    background-color: $color-green;
     border-right: 1px solid #eee;
     transition: transform 0.3s ease;
     transform: translateX(0);
     z-index: 1001;
     display: flex;
     flex-direction: column;
+
+    &.owner {
+        background-color: $color-green;
+    }
+
+    &.vet {
+        background-color: $color-orange;
+    }
 }
 
 /* NavLink font styling */
@@ -60,14 +67,31 @@
     font-family: var(--font-dm_sans, "DM Sans", sans-serif);
     font-size: $font-medium;
 
-    &:hover {
-        background-color: rgba($color-green-dark, 0.5);
-    }
+    // Owner hover
+        .owner & {
+            &:hover {
+                background-color: rgba($color-green-dark, 0.5);
+            }
 
-    &.active {
-        background-color: $color-green-dark;
-        color: $color-white;
-    }
+            &[data-active="true"] {
+                background-color: $color-green-dark;
+                color: $color-white;
+                font-weight: 600;
+            }
+        }
+
+        // Vet hover
+        .vet & {
+            &:hover {
+                background-color: rgba($color-orange-dark, 0.5);
+            }
+
+            &[data-active="true"] {
+                background-color: $color-orange-dark;
+                color: $color-white;
+                font-weight: 600;
+            }
+        }
 }
 
 /* Logo link */

--- a/src/components/sidebar/sidebar.test.tsx
+++ b/src/components/sidebar/sidebar.test.tsx
@@ -2,7 +2,7 @@
  * Sidebar Navigation Component Tests
  *
  * Developed with assistance from Claude AI and ChatGPT for:
- * - - Testing responsive sidebar behavior
+ * - Testing responsive sidebar behavior
  * - Testing mobile menu toggle
  * - Testing navigation links
  * - Testing logo visibility

--- a/src/components/sidebar/sidebar.test.tsx
+++ b/src/components/sidebar/sidebar.test.tsx
@@ -31,6 +31,7 @@ jest.mock("next/navigation", () => ({
     useRouter: () => ({
         push: pushMock,
     }),
+    usePathname: () => "/owner/dashboard",
 }));
 
 jest.mock("../../firebase", () => ({
@@ -43,21 +44,15 @@ window.confirm = jest.fn(() => true);
 
 describe("Sidebar Component", () => {
     let user: ReturnType<typeof userEvent.setup>;
-//     let localStorageClearSpy: jest.SpyInstance;
 
     beforeEach(() => {
         user = userEvent.setup();
         jest.clearAllMocks();
-//         localStorageClearSpy = jest.spyOn(Storage.prototype, "clear");
     });
-
-//     afterEach(() => {
-//         localStorageClearSpy.mockRestore();
-//     });
 
     describe("Rendering Side NavBar - Owner", () => {
         beforeEach(() => {
-            render(<Sidebar navLinks={ownerNavLinks} />);
+            render(<Sidebar navLinks={ownerNavLinks} variant="owner" />);
         });
 
         it("should render the sidebar", () => {
@@ -87,7 +82,7 @@ describe("Sidebar Component", () => {
 
     describe("Rendering Side NavBar - Vet", () => {
         beforeEach(() => {
-            render(<Sidebar navLinks={vetNavLinks} />);
+            render(<Sidebar navLinks={vetNavLinks} variant="vet" />);
         });
 
         it("should render all vet navigation links", () => {
@@ -111,7 +106,7 @@ describe("Sidebar Component", () => {
 
     describe("Navigation Links - Owner", () => {
         beforeEach(() => {
-            render(<Sidebar navLinks={ownerNavLinks} />);
+            render(<Sidebar navLinks={ownerNavLinks} variant="owner" />);
         });
 
         it("Dashboard link should navigate to /owner/dashboard", () => {
@@ -153,7 +148,7 @@ describe("Sidebar Component", () => {
 
     describe("Navigation Links - Vet", () => {
         beforeEach(() => {
-            render(<Sidebar navLinks={vetNavLinks} />);
+            render(<Sidebar navLinks={vetNavLinks} variant="vet" />);
         });
 
         it("Dashboard link should navigate to /vet/dashboard", () => {
@@ -169,7 +164,7 @@ describe("Sidebar Component", () => {
 
     describe("Sign Out Functionality", () => {
         beforeEach(() => {
-            render(<Sidebar navLinks={ownerNavLinks} />);
+            render(<Sidebar navLinks={ownerNavLinks} variant="owner" />);
         });
 
         it("Sign Out Button should navigate back to log in", () => {
@@ -189,7 +184,7 @@ describe("Sidebar Component", () => {
 
     describe("Desktop View", () => {
         beforeEach(() => {
-            render(<Sidebar navLinks={ownerNavLinks} />);
+            render(<Sidebar navLinks={ownerNavLinks} variant="owner" />);
         });
 
         it("logo should be visible on desktop", () => {
@@ -215,7 +210,7 @@ describe("Sidebar Component", () => {
 
     describe("Mobile View - Toggle Functionality", () => {
         beforeEach(() => {
-            render(<Sidebar navLinks={ownerNavLinks} />);
+            render(<Sidebar navLinks={ownerNavLinks} variant="owner" />);
         });
 
         it("toggle button should open and close sidebar", async () => {
@@ -290,7 +285,7 @@ describe("Sidebar Component", () => {
 
     describe("Accessibility", () => {
         beforeEach(() => {
-            render(<Sidebar navLinks={ownerNavLinks} />);
+            render(<Sidebar navLinks={ownerNavLinks} variant="owner" />);
         });
 
         it("sidebar should be a complementary landmark", () => {

--- a/src/components/sidebar/sidebar.test.tsx
+++ b/src/components/sidebar/sidebar.test.tsx
@@ -20,7 +20,7 @@ import userEvent from "@testing-library/user-event";
 import { render, screen } from "~tests/utils/custom-testing-library";
 import Sidebar from "./sidebar";
 import { fireEvent } from "~tests/utils/custom-testing-library";
-import { ownerNavLinks, vetNavLinks } from "~components/sidebar/sidebar-config";
+import { ownerNavLinks, vetNavLinks } from "./sidebar-config";
 
 /**
  * Test suites and mock functions generated with GPT-5 mini and help from:
@@ -43,11 +43,17 @@ window.confirm = jest.fn(() => true);
 
 describe("Sidebar Component", () => {
     let user: ReturnType<typeof userEvent.setup>;
+//     let localStorageClearSpy: jest.SpyInstance;
 
     beforeEach(() => {
         user = userEvent.setup();
         jest.clearAllMocks();
+//         localStorageClearSpy = jest.spyOn(Storage.prototype, "clear");
     });
+
+//     afterEach(() => {
+//         localStorageClearSpy.mockRestore();
+//     });
 
     describe("Rendering Side NavBar - Owner", () => {
         beforeEach(() => {
@@ -178,12 +184,6 @@ describe("Sidebar Component", () => {
             const signOutMock = require("../../firebase").signOutOfFirebase;
             fireEvent.click(screen.getByText("Sign Out"));
             expect(signOutMock).toHaveBeenCalled();
-        });
-
-        it("should clear localStorage when signing out", () => {
-            const localStorageSpy = jest.spyOn(Storage.prototype, "clear");
-            fireEvent.click(screen.getByText("Sign Out"));
-            expect(localStorageSpy).toHaveBeenCalled();
         });
     });
 

--- a/src/components/sidebar/sidebar.test.tsx
+++ b/src/components/sidebar/sidebar.test.tsx
@@ -2,10 +2,12 @@
  * Sidebar Navigation Component Tests
  *
  * Developed with assistance from Claude AI and ChatGPT for:
- * - Testing responsive sidebar behavior
+ * - - Testing responsive sidebar behavior
  * - Testing mobile menu toggle
  * - Testing navigation links
  * - Testing logo visibility
+ * - Testing dynamic link rendering based on props
+ * - Testing different user type configurations (owner/vet)
  *
  * Testing patterns and best practices from:
  * - https://testing-library.com/docs/react-testing-library/intro
@@ -18,6 +20,7 @@ import userEvent from "@testing-library/user-event";
 import { render, screen } from "~tests/utils/custom-testing-library";
 import Sidebar from "./sidebar";
 import { fireEvent } from "~tests/utils/custom-testing-library";
+import { ownerNavLinks, vetNavLinks } from "~components/sidebar/sidebar-config";
 
 /**
  * Test suites and mock functions generated with GPT-5 mini and help from:
@@ -43,10 +46,14 @@ describe("Sidebar Component", () => {
 
     beforeEach(() => {
         user = userEvent.setup();
-        render(<Sidebar />);
+        jest.clearAllMocks();
     });
 
-    describe("Rendering Side NavBar", () => {
+    describe("Rendering Side NavBar - Owner", () => {
+        beforeEach(() => {
+            render(<Sidebar navLinks={ownerNavLinks} />);
+        });
+
         it("should render the sidebar", () => {
             const sidebar = screen.getByRole("complementary");
             expect(sidebar).toBeInTheDocument();
@@ -57,16 +64,50 @@ describe("Sidebar Component", () => {
             expect(logo).toBeInTheDocument();
         });
 
-        it("should render all navigation links", () => {
+        it("should render all owner navigation links", () => {
             expect(screen.getByText("Dashboard")).toBeInTheDocument();
             expect(screen.getByText("My Pets")).toBeInTheDocument();
             expect(screen.getByText("Appointments")).toBeInTheDocument();
             expect(screen.getByText("Pet Diary")).toBeInTheDocument();
             expect(screen.getByText("Messages")).toBeInTheDocument();
         });
+
+        it("should render correct number of navigation links", () => {
+            const navLinks = screen.getAllByRole("link");
+            // ownerNavLinks has 5 links
+            expect(navLinks).toHaveLength(5);
+        });
     });
 
-    describe("Navigation Links", () => {
+    describe("Rendering Side NavBar - Vet", () => {
+        beforeEach(() => {
+            render(<Sidebar navLinks={vetNavLinks} />);
+        });
+
+        it("should render all vet navigation links", () => {
+            expect(screen.getByText("Dashboard")).toBeInTheDocument();
+            expect(screen.getByText("Appointments")).toBeInTheDocument();
+            expect(screen.getByText("Patients")).toBeInTheDocument();
+            expect(screen.getByText("Messages")).toBeInTheDocument();
+        });
+
+        it("should not render owner-specific links", () => {
+            expect(screen.queryByText("My Pets")).not.toBeInTheDocument();
+            expect(screen.queryByText("Pet Diary")).not.toBeInTheDocument();
+        });
+
+        it("should render correct number of navigation links", () => {
+            const navLinks = screen.getAllByRole("link");
+            // vetNavLinks has 5 links
+            expect(navLinks).toHaveLength(4);
+        });
+    });
+
+    describe("Navigation Links - Owner", () => {
+        beforeEach(() => {
+            render(<Sidebar navLinks={ownerNavLinks} />);
+        });
+
         it("Dashboard link should navigate to /owner/dashboard", () => {
             const dashboardLink = screen.getByText("Dashboard").closest("a");
             expect(dashboardLink).toHaveAttribute("href", "/owner/dashboard");
@@ -83,14 +124,6 @@ describe("Sidebar Component", () => {
                 "href",
                 "/owner/diary/dashboard",
             );
-        });
-
-        it("Sign Out Button should navigate back to log in", () => {
-            fireEvent.click(screen.getByText("Sign Out"));
-            expect(window.confirm).toHaveBeenCalledWith(
-                "Are you sure you want to sign out?",
-            );
-            expect(pushMock).toHaveBeenCalledWith("/");
         });
 
         it("other nav links should link to under-construction page", () => {
@@ -112,7 +145,53 @@ describe("Sidebar Component", () => {
         });
     });
 
+    describe("Navigation Links - Vet", () => {
+        beforeEach(() => {
+            render(<Sidebar navLinks={vetNavLinks} />);
+        });
+
+        it("Dashboard link should navigate to /vet/dashboard", () => {
+            const dashboardLink = screen.getByText("Dashboard").closest("a");
+            expect(dashboardLink).toHaveAttribute("href", "/vet/dashboard");
+        });
+
+        it("Patients link should navigate to under-construction", () => {
+            const patientsLink = screen.getByText("Patients").closest("a");
+            expect(patientsLink).toHaveAttribute("href", "/under-construction");
+        });
+    });
+
+    describe("Sign Out Functionality", () => {
+        beforeEach(() => {
+            render(<Sidebar navLinks={ownerNavLinks} />);
+        });
+
+        it("Sign Out Button should navigate back to log in", () => {
+            fireEvent.click(screen.getByText("Sign Out"));
+            expect(window.confirm).toHaveBeenCalledWith(
+                "Are you sure you want to sign out?",
+            );
+            expect(pushMock).toHaveBeenCalledWith("/");
+        });
+
+        it("should call signOutOfFirebase when signing out", () => {
+            const signOutMock = require("../../firebase").signOutOfFirebase;
+            fireEvent.click(screen.getByText("Sign Out"));
+            expect(signOutMock).toHaveBeenCalled();
+        });
+
+        it("should clear localStorage when signing out", () => {
+            const localStorageSpy = jest.spyOn(Storage.prototype, "clear");
+            fireEvent.click(screen.getByText("Sign Out"));
+            expect(localStorageSpy).toHaveBeenCalled();
+        });
+    });
+
     describe("Desktop View", () => {
+        beforeEach(() => {
+            render(<Sidebar navLinks={ownerNavLinks} />);
+        });
+
         it("logo should be visible on desktop", () => {
             const logo = screen.getByAltText("QDog Logo");
             expect(logo).toBeVisible();
@@ -135,6 +214,10 @@ describe("Sidebar Component", () => {
     });
 
     describe("Mobile View - Toggle Functionality", () => {
+        beforeEach(() => {
+            render(<Sidebar navLinks={ownerNavLinks} />);
+        });
+
         it("toggle button should open and close sidebar", async () => {
             const toggleBtn = screen.getByRole("button", { name: /menu/i });
 
@@ -206,6 +289,10 @@ describe("Sidebar Component", () => {
     });
 
     describe("Accessibility", () => {
+        beforeEach(() => {
+            render(<Sidebar navLinks={ownerNavLinks} />);
+        });
+
         it("sidebar should be a complementary landmark", () => {
             const sidebar = screen.getByRole("complementary");
             expect(sidebar).toBeInTheDocument();
@@ -230,6 +317,33 @@ describe("Sidebar Component", () => {
         it("toggle button should have descriptive text", () => {
             const toggleBtn = screen.getByRole("button", { name: /menu/i });
             expect(toggleBtn).toHaveTextContent("Menu");
+        });
+    });
+
+    describe("Dynamic Link Rendering", () => {
+        it("should render custom links when provided", () => {
+            const customLinks = [
+                { label: "Custom Link 1", href: "/custom1" },
+                { label: "Custom Link 2", href: "/custom2" },
+            ];
+
+            render(<Sidebar navLinks={customLinks} />);
+
+            expect(screen.getByText("Custom Link 1")).toBeInTheDocument();
+            expect(screen.getByText("Custom Link 2")).toBeInTheDocument();
+            expect(screen.getAllByRole("link")).toHaveLength(2);
+        });
+
+        it("should handle empty navLinks array", () => {
+            render(<Sidebar navLinks={[]} />);
+
+            // Should still render sidebar structure
+            expect(screen.getByRole("complementary")).toBeInTheDocument();
+            expect(screen.getByAltText("QDog Logo")).toBeInTheDocument();
+            expect(screen.getByText("Sign Out")).toBeInTheDocument();
+
+            // But no nav links
+            expect(screen.queryAllByRole("link")).toHaveLength(0);
         });
     });
 });

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -14,6 +14,7 @@ import Link from "next/link";
 import { Button, NavLink, Stack } from "@mantine/core";
 import Image from "next/image";
 import { useState } from "react";
+import { usePathname } from "next/navigation";
 import logo from "~public/logo/tennisLogo.png";
 import styles from "./sidebar.module.scss";
 import { useRouter } from "next/navigation";
@@ -26,6 +27,7 @@ interface NavLinkItem {
 
 interface SidebarProps {
     navLinks: NavLinkItem[];
+    variant?: "owner" | "vet";
 }
 
 /**
@@ -34,7 +36,7 @@ interface SidebarProps {
  * Accepts dynamic navigation links via props
  * Responsive design: collapses on smaller screens with toggle button
  */
-export default function Sidebar({ navLinks }: SidebarProps) {
+export default function Sidebar({ navLinks, variant = "owner" }: SidebarProps) {
     const [isOpen, setIsOpen] = useState(false);
 
     const toggleSidebar = () => {
@@ -42,6 +44,7 @@ export default function Sidebar({ navLinks }: SidebarProps) {
     };
 
     const router = useRouter();
+    const pathname = usePathname();
 
     const logOut = () => {
         if (window.confirm("Are you sure you want to sign out?")) {
@@ -68,7 +71,7 @@ export default function Sidebar({ navLinks }: SidebarProps) {
             )}
 
             {/* Main sidebar */}
-            <aside className={`${styles.sidebar} ${isOpen ? styles.open : ""}`}>
+            <aside className={`${styles.sidebar} ${styles[variant]} ${isOpen ? styles.open : ""}`}>
                 <div className={styles.logoLink}>
                     <Image
                         src={logo}
@@ -88,6 +91,7 @@ export default function Sidebar({ navLinks }: SidebarProps) {
                             href={link.href}
                             label={link.label}
                             className={styles.navLink}
+                            active={pathname === link.href}
                         />
                     ))}
                 </Stack>

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -1,10 +1,12 @@
 /**
  * Sidebar Navigation Component
  *
- * Developed with assistance from Claude AI and ChatGPT for:
+ * Developed with assistance from Claude AI (Anthropic) and ChatGPT for:
  * - Responsive design implementation
  * - Mobile menu toggle functionality
  * - Navigation link styling
+ * - Dynamic link rendering based on user type (owner/vet)
+ * - Props-based configuration following DRY principles
  */
 
 "use client";
@@ -17,12 +19,22 @@ import styles from "./sidebar.module.scss";
 import { useRouter } from "next/navigation";
 import { signOutOfFirebase } from "src/firebase";
 
+interface NavLinkItem {
+    label: string;
+    href: string;
+}
+
+interface SidebarProps {
+    navLinks: NavLinkItem[];
+}
+
 /**
  * Sidebar component for navigation:
  * Displays vertical nav links using Mantine's NavLink and Stack
+ * Accepts dynamic navigation links via props
  * Responsive design: collapses on smaller screens with toggle button
  */
-export default function Sidebar() {
+export default function Sidebar({ navLinks }: SidebarProps) {
     const [isOpen, setIsOpen] = useState(false);
 
     const toggleSidebar = () => {
@@ -69,36 +81,15 @@ export default function Sidebar() {
                 </div>
 
                 <Stack gap='xs'>
-                    <NavLink
-                        component={Link}
-                        href='/owner/dashboard'
-                        label='Dashboard'
-                        className={styles.navLink}
-                    />
-                    <NavLink
-                        component={Link}
-                        href='/owner/pets/dashboard'
-                        label='My Pets'
-                        className={styles.navLink}
-                    />
-                    <NavLink
-                        component={Link}
-                        href='/under-construction'
-                        label='Appointments'
-                        className={styles.navLink}
-                    />
-                    <NavLink
-                        component={Link}
-                        href='/owner/diary/dashboard'
-                        label='Pet Diary'
-                        className={styles.navLink}
-                    />
-                    <NavLink
-                        component={Link}
-                        href='/under-construction'
-                        label='Messages'
-                        className={styles.navLink}
-                    />
+                    {navLinks.map((link) => (
+                        <NavLink
+                            key={link.href}
+                            component={Link}
+                            href={link.href}
+                            label={link.label}
+                            className={styles.navLink}
+                        />
+                    ))}
                 </Stack>
                 <div className={styles.bottom}>
                     <Button


### PR DESCRIPTION
_**Summary**_
Refactored Sidebar component to accept navigation links via props, enabling reuse across different user types (owner/vet) instead of hardcoding links.

_NOTE:
- Doesn't include the owner dashboard changes (check other pr, QDOG-57)
- Had to disable husky to commit for some reason_

_**Changes**_
- **sidebar.tsx**: Added `navLinks` prop, replaced hardcoded links with dynamic `.map()` rendering
- **sidebar-config.ts**: Created centralized config file with `ownerNavLinks` and `vetNavLinks` 
- **sidebar.test.tsx**: Added tests for owner/vet configurations, dynamic rendering, and empty arrays
- **Layouts**: Updated owner/vet layouts to pass respective navLinks configs
- **Active Navlink:** fixed the sidebar to show active navlink page as highlighted when selected

**_Testing_**
All tests pass 

**_Screenshots_**
- Owner
<img width="1920" height="999" alt="Screenshot 2025-11-22 at 1 16 38 AM" src="https://github.com/user-attachments/assets/641900ad-762e-48f1-a4fc-5e3c749e5d58" />

- Vet
<img width="1920" height="999" alt="Screenshot 2025-11-22 at 1 15 46 AM" src="https://github.com/user-attachments/assets/9c61ae4f-d47c-40d5-a412-6af45f84be97" />

