### PR TITLE
feat(QDOG-192): Add preconnection page for messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ brew install pnpm
 
 Using npm:
 
+**Note:** You should do this in bash if using Windows.
+
 ```bash
 npm install -g pnpm@latest-10
 ```
@@ -58,7 +60,7 @@ NEXT_PUBLIC_GCP_PROJECT_ID=
 NEXT_PUBLIC_GCP_BUCKET=
 ```
 
-### 5: Run the Front End Server
+### 6: Run the Front End Server
 
 ```bash
 pnpm dev
@@ -69,6 +71,8 @@ pnpm dev
 ### Install the dependencies
 
 **Note:** Your IDE might warn you to use the same version of pnpm that we use (see the `packageManager` value in `package.json`). You can safely ignore that warning if your version is higher than what we use. If you use a majorly lower one, you might notice some subtle bugs. For example, being 1 major version (version 9) behind ours (version 10.7) can be bad, but being a few minor versions (version 10.4) behind ours is fine. This is because old PNPM might not successfully read new PNPM lockfiles.
+
+**Note:** You should do this in bash if using Windows.
 
 ```bash
 pnpm install

--- a/src/app/layout.module.scss
+++ b/src/app/layout.module.scss
@@ -2,7 +2,7 @@
 
 /* Main grid layout */
 .globalFonts {
-    h1 {
+    h1, h2 {
         font-family: var(--font-tsukimi_rounded), var(--font-dm_sans), Arial;
     }
 
@@ -58,5 +58,28 @@
     // makes the save button (which is 2nd button) color rose
     button:nth-child(2) {
         background-color: $color-rose;
+    }
+}
+
+.rose_button {
+    background-color: $color-rose;
+    color: $color-white;
+    border: none;
+    border-radius: 8px;
+    padding: 12px 24px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+
+    &:hover {
+        background-color: $color-rose-hover;
+    }
+    
+    &:disabled {
+        background-color: $color-light-gray;
+        color: $color-gray;
+        cursor: not-allowed;
+        opacity: 0.6;
     }
 }

--- a/src/app/layout.module.scss
+++ b/src/app/layout.module.scss
@@ -47,9 +47,16 @@
 .cancel_or_save {
     display: flex;
     gap: 10px;
-    justify-content: flex-end;
     padding-top: 2rem;
-    padding-left: 2rem;
+
+    &.end {
+        justify-content: flex-end;
+    }
+
+    &.center {
+        justify-content: center;
+        align-items: center;
+    }
 
     button {
         width: fit-content;
@@ -58,6 +65,13 @@
     // makes the save button (which is 2nd button) color rose
     button:nth-child(2) {
         background-color: $color-rose;
+
+        &:disabled {
+            background-color: $color-light-gray;
+            color: $color-gray;
+            cursor: not-allowed;
+            opacity: 0.6;
+        }
     }
 }
 

--- a/src/app/owner/diary/create/page.tsx
+++ b/src/app/owner/diary/create/page.tsx
@@ -16,7 +16,7 @@ import { Owner } from "src/models/owner";
 import { PetsAPI } from "~api/petsAPI";
 import { PetDiaryAPI } from "~api/petDiaryAPI";
 import { todayDate, UserRoles } from "~data/constants";
-import { generateDiaryURL, uploadFile, USE_STORAGE } from "src/firebase";
+import { generateDiaryURL, uploadFile } from "src/firebase";
 
 /**
  * Some sample code came from Mantine use-file-dialog
@@ -42,8 +42,6 @@ function NewDiary() {
     }, []);
 
     const [pets, setPets] = useState<Pet[]>([]);
-
-    // TODO: Make a util function for fetching pets and return the pets? to reduce duplicate code
 
     // Load pets when owner is available
     useEffect(() => {
@@ -144,10 +142,6 @@ function NewDiary() {
                     createTimestamp: todayDate,
                     files: pickedFilesList.map((file) => file.name),
                 };
-
-                if (!USE_STORAGE) {
-                    diaryEntryJSON["files"] = [];
-                }
 
                 const diaryEntry = new PetDiary(diaryEntryJSON);
 

--- a/src/app/owner/diary/create/page.tsx
+++ b/src/app/owner/diary/create/page.tsx
@@ -15,8 +15,8 @@ import { Pet } from "src/models/pet";
 import { Owner } from "src/models/owner";
 import { PetsAPI } from "~api/petsAPI";
 import { PetDiaryAPI } from "~api/petDiaryAPI";
-import { todayDate, UserRoles } from "~data/constants";
-import { generateDiaryURL, uploadFile } from "src/firebase";
+import { todayDate } from "~data/constants";
+import { generateDiaryURL, uploadFile, USE_STORAGE } from "src/firebase";
 
 /**
  * Some sample code came from Mantine use-file-dialog
@@ -142,6 +142,10 @@ function NewDiary() {
                     createTimestamp: todayDate,
                     files: pickedFilesList.map((file) => file.name),
                 };
+
+                if (!USE_STORAGE) {
+                    diaryEntryJSON["files"] = [];
+                }
 
                 const diaryEntry = new PetDiary(diaryEntryJSON);
 

--- a/src/app/owner/diary/create/page.tsx
+++ b/src/app/owner/diary/create/page.tsx
@@ -248,7 +248,13 @@ function NewDiary() {
                             )}
                         </div>
 
-                        <div className={globalStyles.cancel_or_save}>
+                        <div
+                            className={
+                                globalStyles.cancel_or_save +
+                                " " +
+                                globalStyles.end
+                            }
+                        >
                             <Button variant='default' onClick={handleCancel}>
                                 Cancel
                             </Button>

--- a/src/app/owner/diary/dashboard/page.module.scss
+++ b/src/app/owner/diary/dashboard/page.module.scss
@@ -137,30 +137,16 @@
 }
 
 /* === New Entry button === */
-.newEntryBtn {
-    background: $color-rose;
-    color: $color-white;
-    border: none;
-    border-radius: 10px;
-    padding: 10px 14px;
-    font-weight: 700;
-    cursor: pointer;
-    transition: background 0.2s ease;
-}
 
-.newEntryBtn span {
+.new_entry_button span {
     display: inline-flex;
     align-items: center;
     gap: 6px;
 }
 
-.newEntryBtn svg {
+.new_entry_button svg {
     padding-top: 4px;
     padding-right: 3px;
-}
-
-.newEntryBtn:hover {
-    background: $color-rose-hover;
 }
 
  /* === Responsive tweaks === */
@@ -169,17 +155,6 @@
          font-size: $font-large;
          font-weight: 700;
          text-align: left;
-     }
-
-     .newEntryBtn {
-         width: auto;
-         font-size: $font-small-med;
-         padding: 10px 14px;
-         display: flex;
-         justify-content: center;
-         align-items: center;
-         gap: 6px;
-         margin-top: -10px;
      }
 
      .controls {

--- a/src/app/owner/diary/dashboard/page.test.tsx
+++ b/src/app/owner/diary/dashboard/page.test.tsx
@@ -8,7 +8,7 @@ import userEvent from "@testing-library/user-event";
 import PetDiaryDashboard from "./page";
 import { PetsAPI } from "~api/petsAPI";
 import { PetDiaryAPI } from "~api/petDiaryAPI";
-import { MOCK_DIARY_ENTRIES, MOCK_DIARY_ENTRY } from "~data/diary/mock";
+import { MOCK_DIARY_ENTRIES } from "~data/diary/mock";
 import { mockPets } from "~data/pets/mock";
 import { mockAuthOwner } from "~data/owner/mock";
 import { toSentenceCase } from "~util/strings/normalize";

--- a/src/app/owner/diary/dashboard/page.tsx
+++ b/src/app/owner/diary/dashboard/page.tsx
@@ -76,8 +76,6 @@ export default function PetDiaryDashboard() {
 
     const [pets, setPets] = useState<Pet[]>([]);
 
-    // TODO: Make a util function for fetching pets and return the pets? to reduce duplicate code
-
     useEffect(() => {
         const fetchPets = async () => {
             if (owner?.id) {
@@ -135,7 +133,9 @@ export default function PetDiaryDashboard() {
             <div className={styles.header}>
                 <h1 className={styles.title}>Pet Diary</h1>
                 <button
-                    className={styles.newEntryBtn}
+                    className={
+                        globalStyles.rose_button + " " + styles.new_entry_button
+                    }
                     onClick={() => router.push("/owner/diary/create")}
                 >
                     <IconPlus size={16} />

--- a/src/app/owner/messages/page.module.scss
+++ b/src/app/owner/messages/page.module.scss
@@ -1,0 +1,33 @@
+@import "~app/globals.scss";
+
+.page {
+    h1 {
+        font-size: $font-xlarge;
+    }
+
+    .page_content {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+    }
+}
+
+.card {
+    display: flex;
+    flex-direction: column;
+    width: fit-content;
+    align-items: center;
+    justify-content: center;
+    margin: 0%;
+    padding: 20px 30px;
+    border: 1px solid $color-light-gray;
+    border-radius: 10px;
+
+    .card_title {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+    }
+}

--- a/src/app/owner/messages/page.tsx
+++ b/src/app/owner/messages/page.tsx
@@ -47,8 +47,9 @@ export default function Messages() {
                     connection.subscribe(
                         websocketOwnerTopics.onlineInit,
                         (msg) => {
-                            const vetsArrayString = msg.body.split(",");
-                            setNumVets(vetsArrayString.length);
+                            const vetsArray = JSON.parse(msg.body);
+                            console.log(vetsArray);
+                            setNumVets(vetsArray.length);
                         },
                     );
                     setWebsocket(connection);

--- a/src/app/owner/messages/page.tsx
+++ b/src/app/owner/messages/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Badge, Box, Button, Card, Grid, SimpleGrid } from "@mantine/core";
+import { Badge, Box, Button, Card, SimpleGrid } from "@mantine/core";
 import styles from "./page.module.scss";
 import globalStyles from "~app/layout.module.scss";
 import { useEffect, useState } from "react";

--- a/src/app/owner/messages/page.tsx
+++ b/src/app/owner/messages/page.tsx
@@ -1,0 +1,174 @@
+"use client";
+import { Badge, Box, Button, Card, Grid, SimpleGrid } from "@mantine/core";
+import styles from "./page.module.scss";
+import globalStyles from "~app/layout.module.scss";
+import { useEffect, useState } from "react";
+import { ImageCheckbox } from "~components/imageCheckbox/imageCheckbox";
+import { useRouter } from "next/navigation";
+import { Pet } from "src/models/pet";
+import { Owner } from "src/models/owner";
+import { getAuthenticatedOwner } from "~util/auth/getAuthenticatedUser";
+import { PetsAPI } from "~api/petsAPI";
+import { generatePetURL, getImageURL } from "src/firebase";
+import placeholderImage from "~public/placeholder.jpg";
+
+export default function MessagesPage() {
+    const [numVets, setNumVets] = useState(0);
+    const [error, setError] = useState("");
+
+    const [showConnectWithVetCard, setConnectWithVetCard] = useState(false);
+    const [selectedPetId, setSelectedPetId] = useState<string | null>(null);
+
+    const router = useRouter();
+
+    const [pets, setPets] = useState<Pet[]>([]);
+    const [imageUrls, setImageUrls] = useState({});
+
+    const [owner, setOwner] = useState<Owner | null>(null);
+
+    useEffect(() => {
+        try {
+            const authenticatedOwner = getAuthenticatedOwner();
+            setOwner(authenticatedOwner);
+        } catch (error) {
+            if (error instanceof Error) {
+                setError(error.message);
+            }
+        }
+    }, []);
+
+    // Load pets when owner is available
+    useEffect(() => {
+        const fetchPets = async () => {
+            if (owner?.id) {
+                try {
+                    const fetchedPets = await PetsAPI.getAllPets(owner.id);
+                    setPets(fetchedPets);
+
+                    const promises = [];
+                    const images = {};
+
+                    for (let pet of fetchedPets) {
+                        promises.push(getPetImage(owner.id, pet, images));
+                    }
+                    await Promise.all(promises);
+
+                    setPets(fetchedPets);
+                    setImageUrls(images);
+                } catch (error) {
+                    setError(
+                        "We can't retrieve all your pets. Please try again later.",
+                    );
+                }
+            }
+        };
+
+        fetchPets();
+    }, [owner]);
+
+    const getPetImage = async (ownerId, pet: Pet, imageDict) => {
+        try {
+            const filePath = generatePetURL(ownerId, pet.id);
+            const url = await getImageURL(filePath);
+            imageDict[pet.id] = url;
+        } catch (error) {
+            imageDict[pet.id] = placeholderImage.src;
+        }
+    };
+
+    const handlePetSelect = (petId: string) => {
+        if (selectedPetId === petId) {
+            // Deselect if clicking the same pet
+            setSelectedPetId(null);
+        } else {
+            // Select the new pet
+            setSelectedPetId(petId);
+        }
+    };
+
+    const items = pets.map((pet) => (
+        <ImageCheckbox
+            disabled={selectedPetId !== null && selectedPetId !== pet.id}
+            checked={selectedPetId === pet.id}
+            onChange={() => handlePetSelect(pet.id)}
+            description={pet.animalGroup.replaceAll("_", " ")}
+            title={pet.name}
+            image={imageUrls[pet.id]}
+            key={pet.id}
+        />
+    ));
+
+    return (
+        <div className={styles.page}>
+            <h1>Messages</h1>
+            <p>Need help? Our vets are here to help.</p>
+
+            <div className={styles.page_content}>
+                <Card padding='sm'>
+                    {/* Select a pet card content */}
+                    {!showConnectWithVetCard && (
+                        <div className={styles.card}>
+                            <div className={styles.card_title}>
+                                <h2>Select a Pet</h2>
+                            </div>
+
+                            <p>
+                                Tell us which pet you are chatting about so the
+                                vet can review their history.
+                            </p>
+                            <SimpleGrid
+                                spacing='md'
+                                cols={{ base: 1, sm: 1, md: 2 }}
+                            >
+                                {items}
+                            </SimpleGrid>
+
+                            <Box mt='xl'>
+                                <Button
+                                    className={globalStyles.rose_button}
+                                    disabled={selectedPetId === null}
+                                    onClick={() => setConnectWithVetCard(true)}
+                                >
+                                    Next
+                                </Button>
+                            </Box>
+                        </div>
+                    )}
+
+                    {/* Connect with a vet card content */}
+                    {showConnectWithVetCard && (
+                        <div className={styles.card}>
+                            <div className={styles.card_title}>
+                                <h2>Connect with a Vet</h2>
+                                <Badge variant='light' color='green'>
+                                    {numVets} vets online
+                                </Badge>
+                            </div>
+
+                            <p>
+                                Start a conversation with a QDOG vet about your
+                                selected pet!
+                            </p>
+
+                            <div className={globalStyles.cancel_or_save}>
+                                <Button
+                                    onClick={() => setConnectWithVetCard(false)}
+                                >
+                                    Cancel
+                                </Button>
+                                <Button
+                                    onClick={() =>
+                                        router.push("/owner/messages/chat")
+                                    }
+                                >
+                                    Connect
+                                </Button>
+                            </div>
+                        </div>
+                    )}
+                </Card>
+                {error && <p className={globalStyles.error_message}>{error}</p>}
+            </div>
+        </div>
+    );
+}

--- a/src/app/owner/messages/page.tsx
+++ b/src/app/owner/messages/page.tsx
@@ -16,6 +16,8 @@ import {
     generateWebSocketUrl,
     websocketOwnerTopics,
 } from "~data/messages/constants";
+import { hasRole } from "~util/auth/authCookies";
+import { UserRoles } from "~data/constants";
 
 export default function Messages() {
     const [numVets, setNumVets] = useState(0);
@@ -45,7 +47,8 @@ export default function Messages() {
                     connection.subscribe(
                         websocketOwnerTopics.onlineInit,
                         (msg) => {
-                            console.log("init" + msg.body);
+                            const vetsArrayString = msg.body.split(",");
+                            setNumVets(vetsArrayString.length);
                         },
                     );
                     setWebsocket(connection);
@@ -62,6 +65,19 @@ export default function Messages() {
             connection.activate();
         }
     }, []);
+
+    useEffect(() => {
+        if (hasRole(UserRoles.owner)) {
+            if (websocket != null) {
+                websocket.subscribe(
+                    websocketOwnerTopics.availableVets,
+                    (msg) => {
+                        console.log(msg);
+                    },
+                );
+            }
+        }
+    }, [websocket]);
 
     // Load pets when owner is available
     useEffect(() => {
@@ -167,7 +183,8 @@ export default function Messages() {
                             <div className={styles.card_title}>
                                 <h2>Connect with a Vet</h2>
                                 <Badge variant='light' color='green'>
-                                    {numVets} vets online
+                                    {numVets <= 1 && numVets + " vet online"}
+                                    {numVets > 1 && numVets + " vets online"}
                                 </Badge>
                             </div>
 

--- a/src/app/owner/messages/page.tsx
+++ b/src/app/owner/messages/page.tsx
@@ -10,7 +10,12 @@ import { Owner } from "src/models/owner";
 import { getAuthenticatedOwner } from "~util/auth/getAuthenticatedUser";
 import { PetsAPI } from "~api/petsAPI";
 import { generatePetURL, getImageURL } from "src/firebase";
+import { Client } from "@stomp/stompjs";
 import placeholderImage from "~public/placeholder.jpg";
+import {
+    generateWebSocketUrl,
+    websocketOwnerTopics,
+} from "~data/messages/constants";
 
 export default function Messages() {
     const [numVets, setNumVets] = useState(0);
@@ -26,14 +31,35 @@ export default function Messages() {
 
     const [owner, setOwner] = useState<Owner | null>(null);
 
+    const [websocket, setWebsocket] = useState<Client>(null);
+
     useEffect(() => {
-        try {
-            const authenticatedOwner = getAuthenticatedOwner();
-            setOwner(authenticatedOwner);
-        } catch (error) {
-            if (error instanceof Error) {
-                setError(error.message);
-            }
+        let owner: Owner = getAuthenticatedOwner();
+        setOwner(owner);
+
+        if (!websocket) {
+            const connection = new Client({
+                brokerURL: generateWebSocketUrl(owner.id),
+                onConnect: () => {
+                    console.log("connected :D ");
+                    connection.subscribe(
+                        websocketOwnerTopics.onlineInit,
+                        (msg) => {
+                            console.log("init" + msg.body);
+                        },
+                    );
+                    setWebsocket(connection);
+                },
+            });
+
+            connection.onStompError = function (frame) {
+                console.log(
+                    "Broker reported error: " + frame.headers["message"],
+                );
+                console.log("Additional details: " + frame.body);
+            };
+
+            connection.activate();
         }
     }, []);
 
@@ -150,7 +176,13 @@ export default function Messages() {
                                 selected pet!
                             </p>
 
-                            <div className={globalStyles.cancel_or_save}>
+                            <div
+                                className={
+                                    globalStyles.cancel_or_save +
+                                    " " +
+                                    globalStyles.center
+                                }
+                            >
                                 <Button
                                     onClick={() => setConnectWithVetCard(false)}
                                 >
@@ -165,11 +197,12 @@ export default function Messages() {
                                     Connect
                                 </Button>
                             </div>
+                            {numVets <= 0 && (
+                                <p>Can't connect yet, no vets are online.</p>
+                            )}
                         </div>
                     )}
                 </Card>
-
-                {numVets <= 0 && <p>Can't connect yet, no vets are online.</p>}
                 {error && <p className={globalStyles.error_message}>{error}</p>}
             </div>
         </div>

--- a/src/app/owner/messages/page.tsx
+++ b/src/app/owner/messages/page.tsx
@@ -12,7 +12,7 @@ import { PetsAPI } from "~api/petsAPI";
 import { generatePetURL, getImageURL } from "src/firebase";
 import placeholderImage from "~public/placeholder.jpg";
 
-export default function MessagesPage() {
+export default function Messages() {
     const [numVets, setNumVets] = useState(0);
     const [error, setError] = useState("");
 
@@ -160,6 +160,7 @@ export default function MessagesPage() {
                                     onClick={() =>
                                         router.push("/owner/messages/chat")
                                     }
+                                    disabled={numVets <= 0}
                                 >
                                     Connect
                                 </Button>
@@ -167,6 +168,8 @@ export default function MessagesPage() {
                         </div>
                     )}
                 </Card>
+
+                {numVets <= 0 && <p>Can't connect yet, no vets are online.</p>}
                 {error && <p className={globalStyles.error_message}>{error}</p>}
             </div>
         </div>

--- a/src/app/owner/pets/create/page.tsx
+++ b/src/app/owner/pets/create/page.tsx
@@ -264,7 +264,11 @@ export default function NewPet() {
                             </div>
                         </div>
                     </div>
-                    <div className={globalStyles.cancel_or_save}>
+                    <div
+                        className={
+                            globalStyles.cancel_or_save + " " + globalStyles.end
+                        }
+                    >
                         <Button variant='default' onClick={handleCancel}>
                             Cancel
                         </Button>

--- a/src/app/owner/pets/dashboard/page.module.scss
+++ b/src/app/owner/pets/dashboard/page.module.scss
@@ -29,22 +29,6 @@
     color: $color-black;
 }
 
-.add_button {
-    background-color: $color-rose;
-    color: $color-white;
-    border: none;
-    border-radius: 8px;
-    padding: 12px 24px;
-    font-size: 14px;
-    font-weight: 500;
-    cursor: pointer;
-    transition: background-color 0.2s ease;
-
-    &:hover {
-        background-color: $color-rose-hover;
-    }
-}
-
 .add_button span {
     display: inline-flex;
     align-items: center;

--- a/src/app/owner/pets/dashboard/page.tsx
+++ b/src/app/owner/pets/dashboard/page.tsx
@@ -54,8 +54,6 @@ export default function PetDashboard() {
     const [pets, setPets] = useState<Pet[]>([]);
     const [imageUrls, setImageUrls] = useState({}); //dictionary
 
-    // TODO: Make a util function for fetching pets and return the pets? to reduce duplicate code
-
     useEffect(() => {
         const fetchPets = async () => {
             if (owner?.id) {
@@ -112,7 +110,9 @@ export default function PetDashboard() {
                 <div className={styles.header}>
                     <h1 className={styles.title}>My Pets</h1>
                     <button
-                        className={styles.add_button}
+                        className={
+                            globalStyles.rose_button + " " + styles.add_button
+                        }
                         onClick={() => router.push("/owner/pets/create")}
                     >
                         <IconPlus size={16} />

--- a/src/components/imageCheckbox/imageCheckbox.module.scss
+++ b/src/components/imageCheckbox/imageCheckbox.module.scss
@@ -1,0 +1,23 @@
+.button {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    transition:
+      background-color 150ms ease,
+      border-color 150ms ease;
+    border-radius: var(--mantine-radius-sm);
+    padding: var(--mantine-spacing-md);
+    border: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-8));
+    background-color: light-dark(var(--mantine-color-white), var(--mantine-color-dark-8));
+  
+    &[data-checked] {
+      border-color: var(--mantine-color-blue-filled);
+      background-color: var(--mantine-color-blue-light);
+    }
+  }
+  
+  .body {
+    flex: 1;
+    margin-left: var(--mantine-spacing-md);
+    margin-right: var(--mantine-spacing-md);
+  }

--- a/src/components/imageCheckbox/imageCheckbox.tsx
+++ b/src/components/imageCheckbox/imageCheckbox.tsx
@@ -1,0 +1,60 @@
+import { Checkbox, Image, Text, UnstyledButton } from "@mantine/core";
+import { useUncontrolled } from "@mantine/hooks";
+import styles from "./imageCheckbox.module.scss";
+
+// Code mostly from https://ui.mantine.dev/category/inputs/
+
+interface ImageCheckboxProps {
+    checked?: boolean;
+    disabled?: boolean;
+    onChange?: (checked: boolean) => void;
+    title: string;
+    description: string;
+    image: string;
+}
+
+export function ImageCheckbox({
+    checked,
+    disabled,
+    onChange,
+    title,
+    description,
+    className,
+    image,
+    ...others
+}: ImageCheckboxProps &
+    Omit<React.ComponentPropsWithoutRef<"button">, keyof ImageCheckboxProps>) {
+    const [value, handleChange] = useUncontrolled({
+        value: checked,
+        finalValue: false,
+        onChange,
+    });
+
+    return (
+        <UnstyledButton
+            {...others}
+            onClick={() => handleChange(!value)}
+            data-checked={value || undefined}
+            className={styles.button}
+        >
+            <Image src={image} alt={title} w={40} h={40} />
+
+            <div className={styles.body}>
+                <Text c='dimmed' size='xs' lh={1} mb={5}>
+                    {description}
+                </Text>
+                <Text fw={500} size='sm' lh={1}>
+                    {title}
+                </Text>
+            </div>
+
+            <Checkbox
+                disabled={disabled}
+                checked={value}
+                onChange={() => {}}
+                tabIndex={-1}
+                styles={{ input: { cursor: "pointer" } }}
+            />
+        </UnstyledButton>
+    );
+}

--- a/src/components/sidebar/sidebar-config.ts
+++ b/src/components/sidebar/sidebar-config.ts
@@ -29,7 +29,7 @@ export const ownerNavLinks: NavLinkItem[] = [
     },
     {
         label: "Messages",
-        href: "/under-construction",
+        href: "/owner/messages",
     },
 ];
 

--- a/src/components/sidebar/sidebar.test.tsx
+++ b/src/components/sidebar/sidebar.test.tsx
@@ -131,7 +131,7 @@ describe("Sidebar Component", () => {
                 "href",
                 "/under-construction",
             );
-            expect(messagesLink).toHaveAttribute("href", "/under-construction");
+            expect(messagesLink).toHaveAttribute("href", "/owner/messages");
         });
 
         it("nav links should have navLink class styling", () => {


### PR DESCRIPTION
- Add preconnection page for messages
- Add button styles to global file
- Add ImageCheckbox component to be used for preconnection page select a pet 
- Modify sidebar config to direct user to correct link for messages
- Disable buttons when pet is not selected or no vets available
- Add websockets to messages page
- Show message when no vet is available for better ux
- Reformat scss to make it reusable
- Add disabled styles
- Modify README to clarify which are bash-specific commands

Pre-connection:
<img width="1906" height="865" alt="image" src="https://github.com/user-attachments/assets/c58b4201-e7f1-4d08-9960-2874a73dae3f" />

Can only select one at a time:
<img width="1917" height="863" alt="image" src="https://github.com/user-attachments/assets/23a10410-36e9-42c0-99dd-d48e18a17a09" />

Pre-connection 2:
<img width="1915" height="875" alt="image" src="https://github.com/user-attachments/assets/c865b9b2-6de5-4943-b360-1184bc0013d0" />

(button will be disabled when 0 vet available, will also say "vets" for 2 or more vets available)
<img width="1919" height="867" alt="image" src="https://github.com/user-attachments/assets/8319df7d-dcbe-48d8-8c2d-96eabb1c8886" />
